### PR TITLE
Add Dockerfile for running openroad-mcp server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,62 @@
-# Test environment with OpenROAD for CI
-FROM openroad/orfs:latest
+# ---------- Stage 1: builder ----------
+# Use OpenROAD image because MCP interacts with OpenROAD flows
+FROM openroad/orfs:latest AS builder
 
-# Install uv (will handle Python installation)
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh
-ENV PATH="/root/.local/bin:$PATH"
+# Install uv (fast Python dependency manager)
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
-# Set working directory
+# Store uv-managed Python in a portable location
+ENV UV_PYTHON_INSTALL_DIR=/opt/python
+
 WORKDIR /app
 
-# Copy project files
-COPY . .
+# Copy dependency manifests first (better Docker layer caching)
+COPY pyproject.toml uv.lock ./
 
-# Install dependencies
-RUN uv sync --all-extras --inexact
+# Install dependencies without project source
+RUN uv sync --frozen --no-dev --no-install-project
 
-# Set environment for tests
-ENV PYTHONPATH=/app/src
-ENV PATH="/app/.venv/bin:/OpenROAD-flow-scripts/tools/install/OpenROAD/bin:/OpenROAD-flow-scripts/tools/install/yosys/bin:$PATH"
+# Now copy project source
+COPY src/ ./src
+COPY README.md ./
+
+# Install the project itself
+RUN uv sync --frozen --no-dev
+
+
+# ---------- Stage 2: runtime ----------
+FROM openroad/orfs:latest AS runtime
+
+# Create non-root runtime user
+RUN useradd --create-home --shell /bin/bash --uid 1000 --no-log-init appuser
+
+WORKDIR /app
+
+# Copy virtual environment and source from builder
+COPY --from=builder --chown=appuser:appuser /app/.venv /app/.venv
+COPY --from=builder --chown=appuser:appuser /app/src /app/src
+COPY --from=builder --chown=appuser:appuser /opt/python /opt/python
+
+# Switch to non-root user
+USER appuser
+
+# Runtime environment
+ENV PYTHONPATH=/app/src \
+    PATH="/app/.venv/bin:/OpenROAD-flow-scripts/tools/install/OpenROAD/bin:/OpenROAD-flow-scripts/tools/install/yosys/bin:$PATH" \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+# Verify runtime works
+RUN /app/.venv/bin/python -c "import openroad_mcp"
+
+# Healthcheck for container orchestration systems
+HEALTHCHECK --interval=30s --timeout=5s \
+  CMD openroad-mcp --help || exit 1
+
+# OCI metadata (good container practice)
+LABEL org.opencontainers.image.source="https://github.com/luarss/openroad-mcp"
+LABEL org.opencontainers.image.description="OpenROAD MCP server container"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 # Default command
-CMD ["bash"]
+ENTRYPOINT ["openroad-mcp"]


### PR DESCRIPTION
Adds a Dockerfile for running the openroad-mcp server in a container.

Tested locally with:
docker build -t openroad-mcp .
docker run -it openroad-mcp

The server starts successfully in stdio mode.

closes : #2 

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/d8346cf2-6300-44ba-9e94-cf79a3d1e7b8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a Dockerfile to provide a reproducible test environment with OpenROAD tooling. The container prepares a project runtime, installs required tooling, syncs project dependencies, configures PYTHONPATH and PATH for the environment, copies project files into the image, and sets a default shell command for interactive use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->