### PR TITLE
Add CI workflow to build and publish Docker image (GHCR)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,38 @@
+---
+name: Build and Publish Docker Image
+
+"on":
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: ${{ github.event_name == 'push' }}
+          tags: ghcr.io/${{ github.repository }}:latest


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to build the OpenROAD MCP Docker image in CI and publish it to GHCR on pushes to main. Pull requests trigger image builds to validate the Docker setup.

The Docker image build was tested locally to ensure the workflow configuration works as expected.

This improves the project’s containerization and CI/CD pipeline and aligns with the GSoC goal of enabling reliable Docker deployment and automated testing .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Automated Docker container image builds and publishing to GitHub Container Registry are now enabled on every push to the main branch, ensuring the latest images are always available and up-to-date. Validation builds also run on pull requests to catch issues early in the development process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->