### PR TITLE
feat: add GUI screenshot support with headless X11 capture

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -14,6 +14,11 @@ COPY . .
 # Install dependencies
 RUN uv sync --all-extras --inexact
 
+# Install X virtual framebuffer and utilities for headless GUI tests
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends xvfb x11-utils imagemagick && \
+    rm -rf /var/lib/apt/lists/*
+
 # Set environment for tests
 ENV PYTHONPATH=/app/src
 ENV PATH="/app/.venv/bin:/OpenROAD-flow-scripts/tools/install/OpenROAD/bin:/OpenROAD-flow-scripts/tools/install/yosys/bin:$PATH"

--- a/README.md
+++ b/README.md
@@ -123,6 +123,11 @@ Once configured, the following tools are available:
 - `get_session_metrics` - Get performance metrics
 - `list_report_images` - List ORFS report directory images
 - `read_report_image` - Read a ORFS report image
+- `gui_screenshot` - Capture a screenshot from the OpenROAD GUI (headless via Xvfb)
+
+### Headless GUI Support
+
+The `gui_screenshot` tool launches OpenROAD's GUI under a virtual X framebuffer (`xvfb-run`) so that screenshots can be captured without a physical display.  When called without a `session_id` the tool automatically creates a headless `xvfb-run openroad -gui` session, invokes the Tcl command `gui::save_image` to render the current view, and returns the resulting PNG as base64-encoded data.  You can also pass an existing GUI session ID to reuse a session that already has a design loaded.  This feature requires `xvfb` to be installed (`apt-get install -y xvfb`) and is pre-configured in the Docker test image.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Once configured, the following tools are available:
 
 ### Headless GUI Support
 
-The `gui_screenshot` tool launches OpenROAD's GUI under a virtual X framebuffer (`xvfb-run`) so that screenshots can be captured without a physical display.  When called without a `session_id` the tool automatically creates a headless `xvfb-run openroad -gui` session, invokes the Tcl command `gui::save_image` to render the current view, and returns the resulting PNG as base64-encoded data.  You can also pass an existing GUI session ID to reuse a session that already has a design loaded.  This feature requires `xvfb` to be installed (`apt-get install -y xvfb`) and is pre-configured in the Docker test image.
+The `gui_screenshot` tool launches OpenROAD's GUI under a persistent **Xvfb** virtual display and captures the screen using ImageMagick's `import -window root` command — no physical display is required.  When called without a `session_id` the tool automatically starts Xvfb, launches `openroad -gui -no_init` on that display, waits for the GUI window to render, and returns the screenshot as base64-encoded JPEG by default (configurable to PNG or WebP).  You can reuse a previously created GUI session by passing its `session_id` (only sessions created by `gui_screenshot` can be reused).  This feature requires `xvfb` and ImageMagick to be installed (`apt-get install -y xvfb imagemagick`) and is pre-configured in the Docker test image.
 
 ## Troubleshooting
 

--- a/src/openroad_mcp/config/settings.py
+++ b/src/openroad_mcp/config/settings.py
@@ -41,6 +41,16 @@ class Settings(BaseModel):
         description="Enable command validation to prevent command injection",
     )
 
+    # GUI screenshot settings
+    GUI_DISPLAY_RESOLUTION: str = Field(
+        default="1280x1024x24",
+        description="Default Xvfb virtual display resolution (WxHxDepth)",
+    )
+    GUI_CAPTURE_TIMEOUT_MS: int = Field(
+        default=8000,
+        description="Timeout in milliseconds for the screenshot capture",
+    )
+
     # ORFS integration settings
     ORFS_FLOW_PATH: str = Field(
         default=os.path.expanduser("~/OpenROAD-flow-scripts/flow"),
@@ -83,6 +93,8 @@ class Settings(BaseModel):
             "READ_CHUNK_SIZE": ("OPENROAD_READ_CHUNK_SIZE", int),
             "LOG_LEVEL": ("LOG_LEVEL", str),
             "LOG_FORMAT": ("LOG_FORMAT", str),
+            "GUI_DISPLAY_RESOLUTION": ("OPENROAD_GUI_DISPLAY_RESOLUTION", str),
+            "GUI_CAPTURE_TIMEOUT_MS": ("OPENROAD_GUI_CAPTURE_TIMEOUT_MS", int),
             "ORFS_FLOW_PATH": ("ORFS_FLOW_PATH", str),
         }
 

--- a/src/openroad_mcp/config/settings.py
+++ b/src/openroad_mcp/config/settings.py
@@ -90,6 +90,30 @@ class Settings(BaseModel):
         default=85,
         description="Default JPEG/WebP quality (1-100). Lower = smaller file, more artifacts",
     )
+    GUI_PREVIEW_SIZE_PX: int = Field(
+        default=256,
+        description="Maximum dimension (px) of the longest side for preview thumbnails",
+    )
+    GUI_XVFB_SETTLE_S: float = Field(
+        default=1.0,
+        description="Seconds to wait after starting Xvfb before checking it is alive",
+    )
+    GUI_SUBPROCESS_TIMEOUT_S: float = Field(
+        default=3.0,
+        description="Timeout (seconds) for short-lived helper subprocesses (xdpyinfo, xwininfo)",
+    )
+    GUI_DISPLAY_FALLBACK_RANGE: int = Field(
+        default=200,
+        description="Random range added to GUI_DISPLAY_START when no free display is found",
+    )
+    GUI_ERROR_TRUNCATE_CHARS: int = Field(
+        default=500,
+        description="Max characters of stderr kept in error messages",
+    )
+    GUI_TEMP_UUID_LENGTH: int = Field(
+        default=12,
+        description="Hex characters from UUID used in temporary screenshot filenames",
+    )
 
     # ORFS integration settings
     ORFS_FLOW_PATH: str = Field(
@@ -145,6 +169,12 @@ class Settings(BaseModel):
             "GUI_APP_READY_POLL_INTERVAL_S": ("OPENROAD_GUI_APP_READY_POLL_INTERVAL_S", float),
             "GUI_DEFAULT_IMAGE_FORMAT": ("OPENROAD_GUI_DEFAULT_IMAGE_FORMAT", str),
             "GUI_DEFAULT_JPEG_QUALITY": ("OPENROAD_GUI_DEFAULT_JPEG_QUALITY", int),
+            "GUI_PREVIEW_SIZE_PX": ("OPENROAD_GUI_PREVIEW_SIZE_PX", int),
+            "GUI_XVFB_SETTLE_S": ("OPENROAD_GUI_XVFB_SETTLE_S", float),
+            "GUI_SUBPROCESS_TIMEOUT_S": ("OPENROAD_GUI_SUBPROCESS_TIMEOUT_S", float),
+            "GUI_DISPLAY_FALLBACK_RANGE": ("OPENROAD_GUI_DISPLAY_FALLBACK_RANGE", int),
+            "GUI_ERROR_TRUNCATE_CHARS": ("OPENROAD_GUI_ERROR_TRUNCATE_CHARS", int),
+            "GUI_TEMP_UUID_LENGTH": ("OPENROAD_GUI_TEMP_UUID_LENGTH", int),
             "ORFS_FLOW_PATH": ("ORFS_FLOW_PATH", str),
         }
 

--- a/src/openroad_mcp/config/settings.py
+++ b/src/openroad_mcp/config/settings.py
@@ -4,7 +4,7 @@ import os
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class Settings(BaseModel):
@@ -114,6 +114,15 @@ class Settings(BaseModel):
         default=12,
         description="Hex characters from UUID used in temporary screenshot filenames",
     )
+
+    @model_validator(mode="after")
+    def _validate_display_range(self) -> "Settings":
+        if self.GUI_DISPLAY_START >= self.GUI_DISPLAY_END:
+            raise ValueError(
+                f"GUI_DISPLAY_START ({self.GUI_DISPLAY_START}) must be less than "
+                f"GUI_DISPLAY_END ({self.GUI_DISPLAY_END})"
+            )
+        return self
 
     # ORFS integration settings
     ORFS_FLOW_PATH: str = Field(

--- a/src/openroad_mcp/config/settings.py
+++ b/src/openroad_mcp/config/settings.py
@@ -50,6 +50,30 @@ class Settings(BaseModel):
         default=8000,
         description="Timeout in milliseconds for the screenshot capture",
     )
+    GUI_MAX_SCREENSHOT_SIZE_MB: int = Field(
+        default=50,
+        description="Maximum allowed screenshot file size in megabytes",
+    )
+    GUI_IMPORT_TIMEOUT_S: float = Field(
+        default=15.0,
+        description="Timeout in seconds for the ImageMagick import subprocess",
+    )
+    GUI_DISPLAY_START: int = Field(
+        default=42,
+        description="Start of the X11 display number range for Xvfb",
+    )
+    GUI_DISPLAY_END: int = Field(
+        default=100,
+        description="End (exclusive) of the X11 display number range for Xvfb",
+    )
+    GUI_STARTUP_TIMEOUT_S: float = Field(
+        default=15.0,
+        description="Maximum seconds to wait for the GUI to become ready",
+    )
+    GUI_STARTUP_POLL_INTERVAL_S: float = Field(
+        default=0.5,
+        description="Seconds between xdpyinfo readiness polls during GUI startup",
+    )
 
     # ORFS integration settings
     ORFS_FLOW_PATH: str = Field(
@@ -95,6 +119,12 @@ class Settings(BaseModel):
             "LOG_FORMAT": ("LOG_FORMAT", str),
             "GUI_DISPLAY_RESOLUTION": ("OPENROAD_GUI_DISPLAY_RESOLUTION", str),
             "GUI_CAPTURE_TIMEOUT_MS": ("OPENROAD_GUI_CAPTURE_TIMEOUT_MS", int),
+            "GUI_MAX_SCREENSHOT_SIZE_MB": ("OPENROAD_GUI_MAX_SCREENSHOT_SIZE_MB", int),
+            "GUI_IMPORT_TIMEOUT_S": ("OPENROAD_GUI_IMPORT_TIMEOUT_S", float),
+            "GUI_DISPLAY_START": ("OPENROAD_GUI_DISPLAY_START", int),
+            "GUI_DISPLAY_END": ("OPENROAD_GUI_DISPLAY_END", int),
+            "GUI_STARTUP_TIMEOUT_S": ("OPENROAD_GUI_STARTUP_TIMEOUT_S", float),
+            "GUI_STARTUP_POLL_INTERVAL_S": ("OPENROAD_GUI_STARTUP_POLL_INTERVAL_S", float),
             "ORFS_FLOW_PATH": ("ORFS_FLOW_PATH", str),
         }
 

--- a/src/openroad_mcp/config/settings.py
+++ b/src/openroad_mcp/config/settings.py
@@ -33,7 +33,7 @@ class Settings(BaseModel):
 
     # Security settings
     ALLOWED_COMMANDS: list[str] = Field(
-        default=["openroad", "xvfb-run"],
+        default=["openroad"],
         description="List of allowed command executables for interactive sessions",
     )
     ENABLE_COMMAND_VALIDATION: bool = Field(

--- a/src/openroad_mcp/config/settings.py
+++ b/src/openroad_mcp/config/settings.py
@@ -33,7 +33,7 @@ class Settings(BaseModel):
 
     # Security settings
     ALLOWED_COMMANDS: list[str] = Field(
-        default=["openroad"],
+        default=["openroad", "xvfb-run"],
         description="List of allowed command executables for interactive sessions",
     )
     ENABLE_COMMAND_VALIDATION: bool = Field(

--- a/src/openroad_mcp/config/settings.py
+++ b/src/openroad_mcp/config/settings.py
@@ -74,6 +74,14 @@ class Settings(BaseModel):
         default=0.5,
         description="Seconds between xdpyinfo readiness polls during GUI startup",
     )
+    GUI_DEFAULT_IMAGE_FORMAT: str = Field(
+        default="jpeg",
+        description="Default image format for screenshots ('png', 'jpeg', or 'webp')",
+    )
+    GUI_DEFAULT_JPEG_QUALITY: int = Field(
+        default=85,
+        description="Default JPEG/WebP quality (1-100). Lower = smaller file, more artifacts",
+    )
 
     # ORFS integration settings
     ORFS_FLOW_PATH: str = Field(
@@ -125,6 +133,8 @@ class Settings(BaseModel):
             "GUI_DISPLAY_END": ("OPENROAD_GUI_DISPLAY_END", int),
             "GUI_STARTUP_TIMEOUT_S": ("OPENROAD_GUI_STARTUP_TIMEOUT_S", float),
             "GUI_STARTUP_POLL_INTERVAL_S": ("OPENROAD_GUI_STARTUP_POLL_INTERVAL_S", float),
+            "GUI_DEFAULT_IMAGE_FORMAT": ("OPENROAD_GUI_DEFAULT_IMAGE_FORMAT", str),
+            "GUI_DEFAULT_JPEG_QUALITY": ("OPENROAD_GUI_DEFAULT_JPEG_QUALITY", int),
             "ORFS_FLOW_PATH": ("ORFS_FLOW_PATH", str),
         }
 

--- a/src/openroad_mcp/config/settings.py
+++ b/src/openroad_mcp/config/settings.py
@@ -122,6 +122,11 @@ class Settings(BaseModel):
                 f"GUI_DISPLAY_START ({self.GUI_DISPLAY_START}) must be less than "
                 f"GUI_DISPLAY_END ({self.GUI_DISPLAY_END})"
             )
+        if self.GUI_DISPLAY_FALLBACK_RANGE <= 0:
+            raise ValueError(
+                "GUI_DISPLAY_FALLBACK_RANGE must be greater than 0 "
+                "(used as modulo divisor in _find_free_display fallback)"
+            )
         return self
 
     # ORFS integration settings

--- a/src/openroad_mcp/config/settings.py
+++ b/src/openroad_mcp/config/settings.py
@@ -127,6 +127,10 @@ class Settings(BaseModel):
                 "GUI_DISPLAY_FALLBACK_RANGE must be greater than 0 "
                 "(used as modulo divisor in _find_free_display fallback)"
             )
+        if self.GUI_STARTUP_POLL_INTERVAL_S <= 0:
+            raise ValueError("GUI_STARTUP_POLL_INTERVAL_S must be greater than 0")
+        if self.GUI_APP_READY_POLL_INTERVAL_S <= 0:
+            raise ValueError("GUI_APP_READY_POLL_INTERVAL_S must be greater than 0")
         return self
 
     # ORFS integration settings

--- a/src/openroad_mcp/config/settings.py
+++ b/src/openroad_mcp/config/settings.py
@@ -74,6 +74,14 @@ class Settings(BaseModel):
         default=0.5,
         description="Seconds between xdpyinfo readiness polls during GUI startup",
     )
+    GUI_APP_READY_TIMEOUT_S: float = Field(
+        default=15.0,
+        description="Max seconds to wait for the OpenROAD GUI window to render after Xvfb is ready",
+    )
+    GUI_APP_READY_POLL_INTERVAL_S: float = Field(
+        default=0.5,
+        description="Polling interval (seconds) when waiting for GUI application window",
+    )
     GUI_DEFAULT_IMAGE_FORMAT: str = Field(
         default="jpeg",
         description="Default image format for screenshots ('png', 'jpeg', or 'webp')",
@@ -133,6 +141,8 @@ class Settings(BaseModel):
             "GUI_DISPLAY_END": ("OPENROAD_GUI_DISPLAY_END", int),
             "GUI_STARTUP_TIMEOUT_S": ("OPENROAD_GUI_STARTUP_TIMEOUT_S", float),
             "GUI_STARTUP_POLL_INTERVAL_S": ("OPENROAD_GUI_STARTUP_POLL_INTERVAL_S", float),
+            "GUI_APP_READY_TIMEOUT_S": ("OPENROAD_GUI_APP_READY_TIMEOUT_S", float),
+            "GUI_APP_READY_POLL_INTERVAL_S": ("OPENROAD_GUI_APP_READY_POLL_INTERVAL_S", float),
             "GUI_DEFAULT_IMAGE_FORMAT": ("OPENROAD_GUI_DEFAULT_IMAGE_FORMAT", str),
             "GUI_DEFAULT_JPEG_QUALITY": ("OPENROAD_GUI_DEFAULT_JPEG_QUALITY", int),
             "ORFS_FLOW_PATH": ("ORFS_FLOW_PATH", str),

--- a/src/openroad_mcp/core/models.py
+++ b/src/openroad_mcp/core/models.py
@@ -208,6 +208,12 @@ class GuiScreenshotResult(BaseResult):
     image_path: str | None = None
     image_format: str | None = None
     size_bytes: int | None = None
+    original_size_bytes: int | None = None
     resolution: str | None = None
     timestamp: str | None = None
+    return_mode: str | None = None
+    compression_applied: bool = False
+    compression_ratio: float | None = None
+    width: int | None = None
+    height: int | None = None
     message: str | None = None

--- a/src/openroad_mcp/core/models.py
+++ b/src/openroad_mcp/core/models.py
@@ -198,3 +198,16 @@ class ReadImageResult(BaseResult):
     image_data: str | None = None
     metadata: ImageMetadata | None = None
     message: str | None = None
+
+
+class GuiScreenshotResult(BaseResult):
+    """Result from a GUI screenshot capture."""
+
+    session_id: str | None = None
+    image_data: str | None = None
+    image_path: str | None = None
+    image_format: str | None = None
+    size_bytes: int | None = None
+    resolution: str | None = None
+    timestamp: str | None = None
+    message: str | None = None

--- a/src/openroad_mcp/server.py
+++ b/src/openroad_mcp/server.py
@@ -166,16 +166,18 @@ async def gui_screenshot(
     or return_mode='preview' (small thumbnail only).  Use image_format='jpeg'
     with quality=60-85 to reduce file sizes by 70-90% compared to raw PNG.
     """
+    # Normalise empty strings from the MCP Inspector to None so the
+    # downstream execute() method applies correct defaults.
     return await gui_screenshot_tool.execute(
-        session_id,
-        resolution,
-        output_path,
+        session_id or None,
+        resolution or None,
+        output_path or None,
         timeout_ms,
-        image_format,
+        image_format or None,
         quality,
         scale,
-        crop,
-        return_mode,
+        crop or None,
+        return_mode or None,
     )
 
 

--- a/src/openroad_mcp/server.py
+++ b/src/openroad_mcp/server.py
@@ -122,20 +122,61 @@ async def gui_screenshot(
     ] = None,
     output_path: Annotated[
         str | None,
-        Field(description="File path to save the PNG screenshot on disk. A temp file is used when omitted."),
+        Field(description="File path to save the screenshot on disk. A temp file is used when omitted."),
     ] = None,
     timeout_ms: Annotated[
         int | None,
         Field(description="Timeout in milliseconds for the screenshot capture. Defaults to 8000."),
+    ] = None,
+    image_format: Annotated[
+        str | None,
+        Field(description="Output format: 'png', 'jpeg', or 'webp'. Defaults to 'jpeg' (smaller, saves tokens)."),
+    ] = None,
+    quality: Annotated[
+        int | None,
+        Field(description="Compression quality for JPEG/WebP (1-100). Ignored for PNG. Defaults to 85."),
+    ] = None,
+    scale: Annotated[
+        float | None,
+        Field(description="Downscale factor (0.0-1.0]. 0.5 = half size. Defaults to 1.0 (no scaling)."),
+    ] = None,
+    crop: Annotated[
+        str | None,
+        Field(description="Pixel region to crop: 'x0 y0 x1 y1'. Applied before scaling. Omit for full image."),
+    ] = None,
+    return_mode: Annotated[
+        str | None,
+        Field(
+            description=(
+                "How to return the result: "
+                "'base64' (full image, default), "
+                "'path' (file path only, saves tokens), "
+                "'preview' (256px thumbnail + file path)."
+            )
+        ),
     ] = None,
 ) -> str:
     """Capture a screenshot from an OpenROAD GUI session running under Xvfb.
 
     Launches a headless OpenROAD GUI on an Xvfb virtual display if no session_id
     is provided.  Uses ImageMagick ``import -window root`` to capture the X11 root
-    window and returns base64-encoded PNG data.
+    window, then post-processes (crop, scale, format conversion) using Pillow.
+
+    For token-efficient usage, set return_mode='path' (no image data returned)
+    or return_mode='preview' (small thumbnail only).  Use image_format='jpeg'
+    with quality=60-85 to reduce file sizes by 70-90% compared to raw PNG.
     """
-    return await gui_screenshot_tool.execute(session_id, resolution, output_path, timeout_ms)
+    return await gui_screenshot_tool.execute(
+        session_id,
+        resolution,
+        output_path,
+        timeout_ms,
+        image_format,
+        quality,
+        scale,
+        crop,
+        return_mode,
+    )
 
 
 async def shutdown_openroad() -> None:

--- a/src/openroad_mcp/server.py
+++ b/src/openroad_mcp/server.py
@@ -131,8 +131,9 @@ async def gui_screenshot(
 ) -> str:
     """Capture a screenshot from an OpenROAD GUI session running under Xvfb.
 
-    Launches a headless OpenROAD GUI via xvfb-run if no session_id is provided.
-    Executes gui::save_image to capture the current view and returns base64-encoded PNG data.
+    Launches a headless OpenROAD GUI on an Xvfb virtual display if no session_id
+    is provided.  Uses ImageMagick ``import -window root`` to capture the X11 root
+    window and returns base64-encoded PNG data.
     """
     return await gui_screenshot_tool.execute(session_id, resolution, output_path, timeout_ms)
 

--- a/src/openroad_mcp/server.py
+++ b/src/openroad_mcp/server.py
@@ -125,21 +125,21 @@ async def gui_screenshot(
         Field(description="File path to save the screenshot on disk. A temp file is used when omitted."),
     ] = "",
     timeout_ms: Annotated[
-        int | None,
+        str,
         Field(description="Timeout in milliseconds for the screenshot capture. Defaults to 8000."),
-    ] = None,
+    ] = "",
     image_format: Annotated[
         str,
         Field(description="Output format: 'png', 'jpeg', or 'webp'. Defaults to 'jpeg' (smaller, saves tokens)."),
     ] = "",
     quality: Annotated[
-        int | None,
+        str,
         Field(description="Compression quality for JPEG/WebP (1-100). Ignored for PNG. Defaults to 85."),
-    ] = None,
+    ] = "",
     scale: Annotated[
-        float | None,
+        str,
         Field(description="Downscale factor (0.0-1.0]. 0.5 = half size. Defaults to 1.0 (no scaling)."),
-    ] = None,
+    ] = "",
     crop: Annotated[
         str,
         Field(
@@ -172,14 +172,22 @@ async def gui_screenshot(
         v = str(v).strip()
         return v if v else None
 
+    def _int(v: str) -> int | None:
+        v = str(v).strip()
+        return int(v) if v else None
+
+    def _float(v: str) -> float | None:
+        v = str(v).strip()
+        return float(v) if v else None
+
     return await gui_screenshot_tool.execute(
         session_id=_clean(session_id),
         resolution=_clean(resolution),
         output_path=_clean(output_path),
-        timeout_ms=timeout_ms,
+        timeout_ms=_int(timeout_ms),
         image_format=_clean(image_format),
-        quality=quality,
-        scale=scale,
+        quality=_int(quality),
+        scale=_float(scale),
         crop=_clean(crop),
         return_mode=_clean(return_mode),
     )

--- a/src/openroad_mcp/server.py
+++ b/src/openroad_mcp/server.py
@@ -113,25 +113,25 @@ async def read_report_image(platform: str, design: str, run_slug: str, image_nam
 @mcp.tool()
 async def gui_screenshot(
     session_id: Annotated[
-        str | None,
+        str,
         Field(description="Existing GUI session ID to reuse. Leave empty to auto-create a new headless session."),
-    ] = None,
+    ] = "",
     resolution: Annotated[
-        str | None,
+        str,
         Field(description="Virtual display resolution, e.g. '1920x1080x24'. Defaults to '1280x1024x24'."),
-    ] = None,
+    ] = "",
     output_path: Annotated[
-        str | None,
+        str,
         Field(description="File path to save the screenshot on disk. A temp file is used when omitted."),
-    ] = None,
+    ] = "",
     timeout_ms: Annotated[
         int | None,
         Field(description="Timeout in milliseconds for the screenshot capture. Defaults to 8000."),
     ] = None,
     image_format: Annotated[
-        str | None,
+        str,
         Field(description="Output format: 'png', 'jpeg', or 'webp'. Defaults to 'jpeg' (smaller, saves tokens)."),
-    ] = None,
+    ] = "",
     quality: Annotated[
         int | None,
         Field(description="Compression quality for JPEG/WebP (1-100). Ignored for PNG. Defaults to 85."),
@@ -141,11 +141,16 @@ async def gui_screenshot(
         Field(description="Downscale factor (0.0-1.0]. 0.5 = half size. Defaults to 1.0 (no scaling)."),
     ] = None,
     crop: Annotated[
-        str | None,
-        Field(description="Pixel region to crop: 'x0 y0 x1 y1'. Applied before scaling. Omit for full image."),
-    ] = None,
+        str,
+        Field(
+            description=(
+                "Pixel region to crop: 'x0,y0,x1,y1' or 'x0 y0 x1 y1'. "
+                "Applied before scaling. Leave empty for full image."
+            )
+        ),
+    ] = "",
     return_mode: Annotated[
-        str | None,
+        str,
         Field(
             description=(
                 "How to return the result: "
@@ -154,30 +159,29 @@ async def gui_screenshot(
                 "'preview' (256px thumbnail + file path)."
             )
         ),
-    ] = None,
+    ] = "",
 ) -> str:
-    """Capture a screenshot from an OpenROAD GUI session running under Xvfb.
+    """Capture a screenshot of the OpenROAD GUI running in a headless display.
 
-    Launches a headless OpenROAD GUI on an Xvfb virtual display if no session_id
-    is provided.  Uses ImageMagick ``import -window root`` to capture the X11 root
-    window, then post-processes (crop, scale, format conversion) using Pillow.
-
-    For token-efficient usage, set return_mode='path' (no image data returned)
-    or return_mode='preview' (small thumbnail only).  Use image_format='jpeg'
-    with quality=60-85 to reduce file sizes by 70-90% compared to raw PNG.
+    Auto-creates a session if session_id is not provided. Use return_mode='path'
+    or 'preview' to save tokens. JPEG with quality=60-85 reduces size by 70-90%.
     """
-    # Normalise empty strings from the MCP Inspector to None so the
-    # downstream execute() method applies correct defaults.
+
+    # Normalise inputs: empty strings → None so execute() applies defaults.
+    def _clean(v: str) -> str | None:
+        v = str(v).strip()
+        return v if v else None
+
     return await gui_screenshot_tool.execute(
-        session_id or None,
-        resolution or None,
-        output_path or None,
-        timeout_ms,
-        image_format or None,
-        quality,
-        scale,
-        crop or None,
-        return_mode or None,
+        session_id=_clean(session_id),
+        resolution=_clean(resolution),
+        output_path=_clean(output_path),
+        timeout_ms=timeout_ms,
+        image_format=_clean(image_format),
+        quality=quality,
+        scale=scale,
+        crop=_clean(crop),
+        return_mode=_clean(return_mode),
     )
 
 

--- a/src/openroad_mcp/server.py
+++ b/src/openroad_mcp/server.py
@@ -172,31 +172,55 @@ async def gui_screenshot(
         v = str(v).strip()
         return v if v else None
 
-    def _int(v: str) -> int | None:
+    def _int(v: str, name: str = "parameter") -> int | None:
         v = str(v).strip()
-        return int(v) if v else None
+        if not v:
+            return None
+        try:
+            return int(v)
+        except ValueError:
+            raise ValueError(f"Invalid integer value for {name}: '{v}'") from None
 
-    def _float(v: str) -> float | None:
+    def _float(v: str, name: str = "parameter") -> float | None:
         v = str(v).strip()
-        return float(v) if v else None
+        if not v:
+            return None
+        try:
+            return float(v)
+        except ValueError:
+            raise ValueError(f"Invalid numeric value for {name}: '{v}'") from None
 
-    return await gui_screenshot_tool.execute(
-        session_id=_clean(session_id),
-        resolution=_clean(resolution),
-        output_path=_clean(output_path),
-        timeout_ms=_int(timeout_ms),
-        image_format=_clean(image_format),
-        quality=_int(quality),
-        scale=_float(scale),
-        crop=_clean(crop),
-        return_mode=_clean(return_mode),
-    )
+    try:
+        return await gui_screenshot_tool.execute(
+            session_id=_clean(session_id),
+            resolution=_clean(resolution),
+            output_path=_clean(output_path),
+            timeout_ms=_int(timeout_ms, "timeout_ms"),
+            image_format=_clean(image_format),
+            quality=_int(quality, "quality"),
+            scale=_float(scale, "scale"),
+            crop=_clean(crop),
+            return_mode=_clean(return_mode),
+        )
+    except ValueError as e:
+        import json
+
+        from .core.models import GuiScreenshotResult
+
+        return json.dumps(
+            GuiScreenshotResult(error="InvalidParameter", message=str(e)).model_dump(),
+            indent=2,
+        )
 
 
 async def shutdown_openroad() -> None:
-    """Gracefully shutdown interactive OpenROAD sessions."""
+    """Gracefully shutdown interactive OpenROAD sessions and GUI displays."""
     try:
         logger.info("Initiating graceful shutdown of OpenROAD services...")
+
+        # Clean up any Xvfb displays managed by the GUI tool
+        for sid in list(gui_screenshot_tool._session_displays):
+            gui_screenshot_tool.cleanup_display(sid)
 
         await manager.cleanup_all()
 

--- a/src/openroad_mcp/server.py
+++ b/src/openroad_mcp/server.py
@@ -1,8 +1,10 @@
 """Main MCP server setup and tool registration."""
 
 import asyncio
+from typing import Annotated
 
 from fastmcp import FastMCP
+from pydantic import Field
 
 from openroad_mcp.config.cli import CLIConfig
 
@@ -110,10 +112,22 @@ async def read_report_image(platform: str, design: str, run_slug: str, image_nam
 # GUI tools
 @mcp.tool()
 async def gui_screenshot(
-    session_id: str | None = None,
-    resolution: str | None = None,
-    output_path: str | None = None,
-    timeout_ms: int | None = None,
+    session_id: Annotated[
+        str | None,
+        Field(description="Existing GUI session ID to reuse. Leave empty to auto-create a new headless session."),
+    ] = None,
+    resolution: Annotated[
+        str | None,
+        Field(description="Virtual display resolution, e.g. '1920x1080x24'. Defaults to '1280x1024x24'."),
+    ] = None,
+    output_path: Annotated[
+        str | None,
+        Field(description="File path to save the PNG screenshot on disk. A temp file is used when omitted."),
+    ] = None,
+    timeout_ms: Annotated[
+        int | None,
+        Field(description="Timeout in milliseconds for the screenshot capture. Defaults to 8000."),
+    ] = None,
 ) -> str:
     """Capture a screenshot from an OpenROAD GUI session running under Xvfb.
 

--- a/src/openroad_mcp/server.py
+++ b/src/openroad_mcp/server.py
@@ -7,6 +7,7 @@ from fastmcp import FastMCP
 from openroad_mcp.config.cli import CLIConfig
 
 from .core.manager import OpenROADManager
+from .tools.gui import GuiScreenshotTool
 from .tools.interactive import (
     CreateSessionTool,
     InspectSessionTool,
@@ -40,6 +41,9 @@ session_metrics_tool = SessionMetricsTool(manager)
 # Initialize report image tool instances
 list_report_images_tool = ListReportImagesTool(manager)
 read_report_image_tool = ReadReportImageTool(manager)
+
+# Initialize GUI tool instances
+gui_screenshot_tool = GuiScreenshotTool(manager)
 
 
 # Interactive session tools
@@ -101,6 +105,22 @@ async def list_report_images(platform: str, design: str, run_slug: str, stage: s
 async def read_report_image(platform: str, design: str, run_slug: str, image_name: str) -> str:
     """Read a report image and return base64-encoded data with metadata."""
     return await read_report_image_tool.execute(platform, design, run_slug, image_name)
+
+
+# GUI tools
+@mcp.tool()
+async def gui_screenshot(
+    session_id: str | None = None,
+    resolution: str | None = None,
+    output_path: str | None = None,
+    timeout_ms: int | None = None,
+) -> str:
+    """Capture a screenshot from an OpenROAD GUI session running under Xvfb.
+
+    Launches a headless OpenROAD GUI via xvfb-run if no session_id is provided.
+    Executes gui::save_image to capture the current view and returns base64-encoded PNG data.
+    """
+    return await gui_screenshot_tool.execute(session_id, resolution, output_path, timeout_ms)
 
 
 async def shutdown_openroad() -> None:

--- a/src/openroad_mcp/tools/__init__.py
+++ b/src/openroad_mcp/tools/__init__.py
@@ -1,5 +1,6 @@
 """MCP tools for OpenROAD operations."""
 
+from .gui import GuiScreenshotTool
 from .interactive import (
     CreateSessionTool,
     InspectSessionTool,
@@ -12,6 +13,7 @@ from .interactive import (
 
 __all__ = [
     "CreateSessionTool",
+    "GuiScreenshotTool",
     "InspectSessionTool",
     "InteractiveShellTool",
     "ListSessionsTool",

--- a/src/openroad_mcp/tools/base.py
+++ b/src/openroad_mcp/tools/base.py
@@ -9,6 +9,7 @@ from ..core.models import (
     CommandHistoryResult,
     CommandResult,
     ContextInfo,
+    GuiScreenshotResult,
     InteractiveExecResult,
     InteractiveSessionInfo,
     InteractiveSessionListResult,
@@ -51,6 +52,7 @@ class BaseTool(ABC):
             | SessionMetricsResult
             | ListImagesResult
             | ReadImageResult
+            | GuiScreenshotResult
         ),
     ) -> str:
         """Format result as JSON string."""

--- a/src/openroad_mcp/tools/gui.py
+++ b/src/openroad_mcp/tools/gui.py
@@ -151,6 +151,64 @@ async def _wait_for_display(display_num: int) -> bool:
     return False
 
 
+async def _wait_for_gui_ready(display_num: int) -> bool:
+    """Poll *xwininfo -root -children* until a real application window appears.
+
+    ``_wait_for_display`` only confirms that Xvfb is accepting connections.
+    This function waits for OpenROAD's Qt GUI to create a child window on
+    the root, meaning the application has actually rendered.
+
+    Returns ``True`` when an application window is detected, ``False`` on
+    timeout.
+    """
+    timeout = settings.GUI_APP_READY_TIMEOUT_S
+    interval = settings.GUI_APP_READY_POLL_INTERVAL_S
+    display_env = {**os.environ, "DISPLAY": f":{display_num}"}
+    elapsed = 0.0
+
+    while elapsed < timeout:
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "xwininfo",
+                "-root",
+                "-children",
+                env=display_env,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=3.0)
+            if proc.returncode == 0:
+                output = stdout.decode("utf-8", errors="replace")
+                # Count lines that look like real child windows.
+                # xwininfo output for children has lines like:
+                #   0x1400001 (has no name): ("openroad" "OpenROAD")  1280x1024+0+0...
+                # We look for indented hex window IDs under the "children:" section.
+                child_lines = [
+                    line
+                    for line in output.splitlines()
+                    if line.strip().startswith("0x") and "child" not in line.lower()
+                ]
+                if child_lines:
+                    logger.debug(
+                        "GUI window detected on :%d after %.1fs (%d children)",
+                        display_num,
+                        elapsed,
+                        len(child_lines),
+                    )
+                    return True
+        except (TimeoutError, OSError):
+            pass
+        await asyncio.sleep(interval)
+        elapsed += interval
+
+    logger.warning(
+        "No GUI window detected on :%d after %.1fs -- proceeding anyway",
+        display_num,
+        timeout,
+    )
+    return False
+
+
 # ---------------------------------------------------------------------------
 # Tool
 # ---------------------------------------------------------------------------
@@ -636,5 +694,9 @@ class GuiScreenshotTool(BaseTool):
 
         # Wait for the X11 display to become ready (replaces fixed sleep)
         await _wait_for_display(display_num)
+
+        # Wait for OpenROAD GUI to create an actual window (prevents
+        # capturing a blank/black frame before the app has rendered).
+        await _wait_for_gui_ready(display_num)
 
         return session_id

--- a/src/openroad_mcp/tools/gui.py
+++ b/src/openroad_mcp/tools/gui.py
@@ -127,9 +127,14 @@ async def _wait_for_display(display_num: int) -> bool:
     timeout = settings.GUI_STARTUP_TIMEOUT_S
     interval = settings.GUI_STARTUP_POLL_INTERVAL_S
     display_env = {**os.environ, "DISPLAY": f":{display_num}"}
-    elapsed = 0.0
 
-    while elapsed < timeout:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+
+    while True:
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            break
         proc = None
         try:
             proc = await asyncio.create_subprocess_exec(
@@ -138,9 +143,9 @@ async def _wait_for_display(display_num: int) -> bool:
                 stdout=asyncio.subprocess.DEVNULL,
                 stderr=asyncio.subprocess.DEVNULL,
             )
-            rc = await asyncio.wait_for(proc.wait(), timeout=settings.GUI_SUBPROCESS_TIMEOUT_S)
+            rc = await asyncio.wait_for(proc.wait(), timeout=min(settings.GUI_SUBPROCESS_TIMEOUT_S, remaining))
             if rc == 0:
-                logger.debug("Display :%d ready after %.1fs", display_num, elapsed)
+                logger.debug("Display :%d ready after %.1fs", display_num, timeout - remaining)
                 return True
         except TimeoutError:
             if proc is not None:
@@ -148,8 +153,7 @@ async def _wait_for_display(display_num: int) -> bool:
                 await proc.wait()
         except OSError:
             pass
-        await asyncio.sleep(interval)
-        elapsed += interval
+        await asyncio.sleep(min(interval, max(deadline - loop.time(), 0)))
 
     logger.warning(
         "Display :%d not ready after %.1fs – proceeding anyway",
@@ -172,9 +176,14 @@ async def _wait_for_gui_ready(display_num: int) -> bool:
     timeout = settings.GUI_APP_READY_TIMEOUT_S
     interval = settings.GUI_APP_READY_POLL_INTERVAL_S
     display_env = {**os.environ, "DISPLAY": f":{display_num}"}
-    elapsed = 0.0
 
-    while elapsed < timeout:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+
+    while True:
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            break
         proc = None
         try:
             proc = await asyncio.create_subprocess_exec(
@@ -185,13 +194,11 @@ async def _wait_for_gui_ready(display_num: int) -> bool:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.DEVNULL,
             )
-            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=settings.GUI_SUBPROCESS_TIMEOUT_S)
+            stdout, _ = await asyncio.wait_for(
+                proc.communicate(), timeout=min(settings.GUI_SUBPROCESS_TIMEOUT_S, remaining)
+            )
             if proc.returncode == 0:
                 output = stdout.decode("utf-8", errors="replace")
-                # Count lines that look like real child windows.
-                # xwininfo output for children has lines like:
-                #   0x1400001 (has no name): ("openroad" "OpenROAD")  1280x1024+0+0...
-                # We look for indented hex window IDs under the "children:" section.
                 child_lines = [
                     line
                     for line in output.splitlines()
@@ -201,7 +208,7 @@ async def _wait_for_gui_ready(display_num: int) -> bool:
                     logger.debug(
                         "GUI window detected on :%d after %.1fs (%d children)",
                         display_num,
-                        elapsed,
+                        timeout - remaining,
                         len(child_lines),
                     )
                     return True
@@ -211,8 +218,7 @@ async def _wait_for_gui_ready(display_num: int) -> bool:
                 await proc.wait()
         except OSError:
             pass
-        await asyncio.sleep(interval)
-        elapsed += interval
+        await asyncio.sleep(min(interval, max(deadline - loop.time(), 0)))
 
     logger.warning(
         "No GUI window detected on :%d after %.1fs -- proceeding anyway",

--- a/src/openroad_mcp/tools/gui.py
+++ b/src/openroad_mcp/tools/gui.py
@@ -1,13 +1,38 @@
-"""GUI screenshot tool for headless OpenROAD GUI sessions."""
+"""GUI screenshot tool for headless OpenROAD GUI sessions.
+
+Strategy
+--------
+OpenROAD in ``-gui`` mode does **not** read Tcl commands from stdin /
+the PTY.  The Tcl console is a Qt widget whose I/O is internal to the
+application.  This means the PTY-based ``execute_command`` path cannot
+be used to call ``gui::save_image``.
+
+Instead we capture what the virtual framebuffer is showing by using
+ImageMagick's ``import -window root`` command, which grabs the X11
+root window.  This reliably produces a PNG of the full GUI regardless
+of whether a design is loaded.
+
+The lifecycle is:
+
+1. Start **Xvfb** on a deterministic display number.
+2. Launch ``openroad -gui -no_init`` via the session manager with
+   ``DISPLAY`` pointed at that Xvfb instance.
+3. Sleep for a few seconds so Qt / OpenGL can initialise.
+4. Run ``import -window root <path>`` on the same ``DISPLAY``.
+5. Read the resulting PNG and return it as base-64.
+"""
 
 import asyncio
 import base64
+import os
 import shutil
+import signal
 import tempfile
 import uuid
 from datetime import datetime
 from pathlib import Path
 
+from ..core.manager import OpenROADManager
 from ..core.models import GuiScreenshotResult
 from ..interactive.models import SessionError, SessionNotFoundError, SessionTerminatedError
 from ..utils.logging import get_logger
@@ -15,32 +40,84 @@ from .base import BaseTool
 
 logger = get_logger("gui_tools")
 
-# Default virtual framebuffer geometry
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Default virtual framebuffer geometry  (WxHxDepth)
 DEFAULT_DISPLAY_RESOLUTION = "1280x1024x24"
 
-# Timeout for GUI startup and image capture (ms)
+# Timeout defaults (ms)
 GUI_STARTUP_TIMEOUT_MS = 10_000
 IMAGE_CAPTURE_TIMEOUT_MS = 8_000
 
 # Maximum screenshot file size (MB)
 MAX_SCREENSHOT_SIZE_MB = 50
 
-# Tcl template: open the GUI, wait for rendering, save the image, then continue
-# The `after` callbacks give the GUI event loop time to render before capture.
-_SAVE_IMAGE_TCL = 'gui::save_image "{path}"'
+# How long to sleep after starting OpenROAD before capturing.
+# In Docker the Qt / OpenGL init takes 4-6 s.
+_GUI_INIT_SLEEP = 6.0
 
-# Polling settings for waiting on the screenshot file
-_FILE_POLL_INTERVAL = 0.5  # seconds between polls
-_FILE_POLL_MAX_WAIT = 5.0  # total seconds to wait for non-empty file
+# Timeout for the ``import`` subprocess (seconds)
+_IMPORT_TIMEOUT = 15.0
+
+# Range of X11 display numbers to try when looking for a free one
+_DISPLAY_RANGE = range(42, 100)
+
+
+# ---------------------------------------------------------------------------
+# Pre-flight helpers
+# ---------------------------------------------------------------------------
 
 
 def _xvfb_available() -> bool:
-    """Check whether xvfb-run is on PATH."""
-    return shutil.which("xvfb-run") is not None
+    """Check whether Xvfb is on PATH."""
+    return shutil.which("Xvfb") is not None
+
+
+def _openroad_available() -> bool:
+    """Check whether openroad is on PATH."""
+    return shutil.which("openroad") is not None
+
+
+def _import_available() -> bool:
+    """Check whether ImageMagick ``import`` is on PATH."""
+    return shutil.which("import") is not None
+
+
+def _find_free_display() -> int:
+    """Return the first display number without an X lock file."""
+    for num in _DISPLAY_RANGE:
+        lock = Path(f"/tmp/.X{num}-lock")
+        if not lock.exists():
+            return num
+    # Fallback – use a high random number
+    return 42 + uuid.uuid4().int % 200
+
+
+# ---------------------------------------------------------------------------
+# Tool
+# ---------------------------------------------------------------------------
 
 
 class GuiScreenshotTool(BaseTool):
-    """Capture a screenshot from an OpenROAD GUI session running under Xvfb."""
+    """Capture a screenshot from an OpenROAD GUI session running under Xvfb.
+
+    Screenshots are taken by grabbing the X11 root window with
+    ImageMagick's ``import`` utility rather than by sending Tcl commands
+    through the PTY (which OpenROAD ignores in GUI mode).
+    """
+
+    def __init__(self, manager: OpenROADManager) -> None:
+        super().__init__(manager)
+        # session_id  →  display number used by its Xvfb
+        self._session_displays: dict[str, int] = {}
+        # session_id  →  Xvfb subprocess PID (for cleanup)
+        self._xvfb_pids: dict[str, int] = {}
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
 
     async def execute(
         self,
@@ -55,7 +132,7 @@ class GuiScreenshotTool(BaseTool):
         ----------
         session_id:
             Existing GUI-enabled session to reuse.  When *None* a fresh
-            ``xvfb-run openroad -gui`` session is created automatically.
+            headless GUI session is created automatically.
         resolution:
             Virtual display size, e.g. ``"1920x1080x24"``.
             Defaults to ``1280x1024x24``.
@@ -72,29 +149,23 @@ class GuiScreenshotTool(BaseTool):
             # 1.  Ensure we have a GUI-capable session
             # ----------------------------------------------------------
             if session_id is None:
-                if not _xvfb_available():
-                    return self._format_result(
-                        GuiScreenshotResult(
-                            error="XvfbNotFound",
-                            message=("xvfb-run is not installed.  Install it with: apt-get install -y xvfb"),
-                        )
+                session_id = await self._create_gui_session(actual_resolution)
+                if session_id.startswith("{"):
+                    # _create_gui_session returned a JSON error string
+                    return session_id
+
+            display_num = self._session_displays.get(session_id)
+            if display_num is None:
+                return self._format_result(
+                    GuiScreenshotResult(
+                        session_id=session_id,
+                        error="SessionNotFound",
+                        message=(
+                            f"Session {session_id} has no associated X display.  "
+                            "Only sessions created by gui_screenshot can be reused."
+                        ),
                     )
-
-                session_id = await self.manager.create_session(
-                    command=[
-                        "xvfb-run",
-                        "-a",  # auto-pick a free display
-                        "-s",
-                        f"-screen 0 {actual_resolution}",
-                        "openroad",
-                        "-gui",
-                        "-no_init",
-                    ],
                 )
-                logger.info("Created headless GUI session %s", session_id)
-
-                # Give the GUI event loop time to initialise
-                await asyncio.sleep(3.0)
 
             # ----------------------------------------------------------
             # 2.  Determine output file path
@@ -102,50 +173,65 @@ class GuiScreenshotTool(BaseTool):
             if output_path:
                 image_path = Path(output_path)
             else:
-                # Build a path without pre-creating the file so we can
-                # reliably detect whether gui::save_image wrote anything.
                 tmp_dir = Path(tempfile.gettempdir())
                 tmp_name = f"openroad_gui_{uuid.uuid4().hex[:12]}.png"
                 image_path = tmp_dir / tmp_name
 
-            # Remove any stale file so the existence check is meaningful
             image_path.unlink(missing_ok=True)
 
             # ----------------------------------------------------------
-            # 3.  Ask OpenROAD to save the current view
+            # 3.  Capture the X11 root window via ImageMagick import
             # ----------------------------------------------------------
-            save_cmd = _SAVE_IMAGE_TCL.format(path=image_path)
-            result = await self.manager.execute_command(
-                session_id,
-                save_cmd,
-                actual_timeout,
+            display_env = {**os.environ, "DISPLAY": f":{display_num}"}
+            import_timeout = actual_timeout / 1000.0
+
+            proc = await asyncio.create_subprocess_exec(
+                "import",
+                "-window",
+                "root",
+                str(image_path),
+                env=display_env,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
             )
 
-            # ----------------------------------------------------------
-            # 3b. Poll until the file appears with non-zero content.
-            #     gui::save_image may need several event-loop ticks to
-            #     render the frame buffer and flush the PNG to disk.
-            # ----------------------------------------------------------
-            elapsed = 0.0
-            while elapsed < _FILE_POLL_MAX_WAIT:
-                if image_path.exists() and image_path.stat().st_size > 0:
-                    break
-                await asyncio.sleep(_FILE_POLL_INTERVAL)
-                elapsed += _FILE_POLL_INTERVAL
+            try:
+                stdout, stderr = await asyncio.wait_for(
+                    proc.communicate(),
+                    timeout=import_timeout,
+                )
+            except TimeoutError:
+                proc.kill()
+                return self._format_result(
+                    GuiScreenshotResult(
+                        session_id=session_id,
+                        error="ScreenshotFailed",
+                        message=(
+                            f"ImageMagick import timed out after {import_timeout:.0f}s.  "
+                            "The Xvfb display may not be responding."
+                        ),
+                    )
+                )
+
+            if proc.returncode != 0:
+                err_text = stderr.decode("utf-8", errors="replace")[:500]
+                return self._format_result(
+                    GuiScreenshotResult(
+                        session_id=session_id,
+                        error="ScreenshotFailed",
+                        message=f"ImageMagick import failed (rc={proc.returncode}): {err_text}",
+                    )
+                )
 
             # ----------------------------------------------------------
-            # 4.  Read the image and return base64-encoded data
+            # 4.  Validate & return the captured image
             # ----------------------------------------------------------
             if not image_path.exists() or image_path.stat().st_size == 0:
                 return self._format_result(
                     GuiScreenshotResult(
                         session_id=session_id,
                         error="ScreenshotFailed",
-                        message=(
-                            f"Screenshot file was not created (or is empty) at {image_path}.  "
-                            "The GUI may not have finished rendering yet.  "
-                            f"OpenROAD output: {result.output[:500]}"
-                        ),
+                        message=f"Screenshot file was not created at {image_path}.",
                     )
                 )
 
@@ -207,3 +293,101 @@ class GuiScreenshotTool(BaseTool):
                     message=f"Failed to capture GUI screenshot: {e}",
                 )
             )
+
+    # ------------------------------------------------------------------
+    # Cleanup helper – call when tearing down sessions
+    # ------------------------------------------------------------------
+
+    def cleanup_display(self, session_id: str) -> None:
+        """Kill the Xvfb process associated with *session_id*."""
+        pid = self._xvfb_pids.pop(session_id, None)
+        self._session_displays.pop(session_id, None)
+        if pid is not None:
+            try:
+                os.kill(pid, signal.SIGTERM)
+                logger.info("Killed Xvfb (pid %d) for session %s", pid, session_id)
+            except OSError:
+                pass  # already dead
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _create_gui_session(self, resolution: str) -> str:
+        """Start Xvfb + OpenROAD and return the new session id.
+
+        Returns either a valid session-id string or a pre-formatted JSON
+        error string (starts with ``{``).
+        """
+        if not _xvfb_available():
+            return self._format_result(
+                GuiScreenshotResult(
+                    error="XvfbNotFound",
+                    message="Xvfb is not installed.  Install it with: apt-get install -y xvfb",
+                )
+            )
+
+        if not _openroad_available():
+            return self._format_result(
+                GuiScreenshotResult(
+                    error="OpenROADNotFound",
+                    message=(
+                        "openroad is not installed or not on PATH.  "
+                        "GUI screenshots require OpenROAD with GUI support.  "
+                        "See https://openroad.readthedocs.io/ for installation."
+                    ),
+                )
+            )
+
+        if not _import_available():
+            return self._format_result(
+                GuiScreenshotResult(
+                    error="ImportNotFound",
+                    message=("ImageMagick 'import' is not installed.  Install it with: apt-get install -y imagemagick"),
+                )
+            )
+
+        # --- Start Xvfb on a free display ---
+        display_num = _find_free_display()
+
+        xvfb_proc = await asyncio.create_subprocess_exec(
+            "Xvfb",
+            f":{display_num}",
+            "-screen",
+            "0",
+            resolution,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+
+        # Give Xvfb a moment to bind the display socket
+        await asyncio.sleep(1.0)
+
+        # Check that Xvfb is still running
+        if xvfb_proc.returncode is not None:
+            return self._format_result(
+                GuiScreenshotResult(
+                    error="XvfbStartFailed",
+                    message=f"Xvfb exited immediately (rc={xvfb_proc.returncode}) on display :{display_num}.",
+                )
+            )
+
+        # --- Start OpenROAD on that display ---
+        session_id = await self.manager.create_session(
+            command=["openroad", "-gui", "-no_init"],
+            env={"DISPLAY": f":{display_num}"},
+        )
+
+        self._session_displays[session_id] = display_num
+        self._xvfb_pids[session_id] = xvfb_proc.pid
+        logger.info(
+            "Created headless GUI session %s on display :%d (Xvfb pid %d)",
+            session_id,
+            display_num,
+            xvfb_proc.pid,
+        )
+
+        # Wait for Qt / OpenGL to finish initialising
+        await asyncio.sleep(_GUI_INIT_SLEEP)
+
+        return session_id

--- a/src/openroad_mcp/tools/gui.py
+++ b/src/openroad_mcp/tools/gui.py
@@ -17,7 +17,8 @@ The lifecycle is:
 1. Start **Xvfb** on a deterministic display number.
 2. Launch ``openroad -gui -no_init`` via the session manager with
    ``DISPLAY`` pointed at that Xvfb instance.
-3. Sleep for a few seconds so Qt / OpenGL can initialise.
+3. Poll the display with ``xdpyinfo`` until a window appears (with a
+   configurable timeout fallback).
 4. Run ``import -window root <path>`` on the same ``DISPLAY``.
 5. Read the resulting PNG and return it as base-64.
 """
@@ -42,24 +43,11 @@ from .base import BaseTool
 logger = get_logger("gui_tools")
 
 # ---------------------------------------------------------------------------
-# Constants
+# Derived constants – computed once from centralised settings.
+# Module-level names kept for backward compatibility and test imports.
 # ---------------------------------------------------------------------------
 
-# Timeout defaults (ms)
-GUI_STARTUP_TIMEOUT_MS = 10_000
-
-# Maximum screenshot file size (MB)
-MAX_SCREENSHOT_SIZE_MB = 50
-
-# How long to sleep after starting OpenROAD before capturing.
-# In Docker the Qt / OpenGL init takes 4-6 s.
-_GUI_INIT_SLEEP = 6.0
-
-# Timeout for the ``import`` subprocess (seconds)
-_IMPORT_TIMEOUT = 15.0
-
-# Range of X11 display numbers to try when looking for a free one
-_DISPLAY_RANGE = range(42, 100)
+MAX_SCREENSHOT_SIZE_MB: int = settings.GUI_MAX_SCREENSHOT_SIZE_MB
 
 
 # ---------------------------------------------------------------------------
@@ -102,12 +90,52 @@ def _import_available() -> bool:
 
 def _find_free_display() -> int:
     """Return the first display number without an X lock file."""
-    for num in _DISPLAY_RANGE:
+    start = settings.GUI_DISPLAY_START
+    end = settings.GUI_DISPLAY_END
+    for num in range(start, end):
         lock = Path(f"/tmp/.X{num}-lock")
         if not lock.exists():
             return num
-    # Fallback – use a high random number
-    return 42 + uuid.uuid4().int % 200
+    # Fallback – use a high random number outside the configured range
+    return start + uuid.uuid4().int % 200
+
+
+async def _wait_for_display(display_num: int) -> bool:
+    """Poll *xdpyinfo* until the display is ready or the timeout expires.
+
+    Returns ``True`` when the display is responsive, ``False`` on timeout.
+    The timeout and polling interval are read from
+    ``settings.GUI_STARTUP_TIMEOUT_S`` and
+    ``settings.GUI_STARTUP_POLL_INTERVAL_S``.
+    """
+    timeout = settings.GUI_STARTUP_TIMEOUT_S
+    interval = settings.GUI_STARTUP_POLL_INTERVAL_S
+    display_env = {**os.environ, "DISPLAY": f":{display_num}"}
+    elapsed = 0.0
+
+    while elapsed < timeout:
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "xdpyinfo",
+                env=display_env,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            rc = await asyncio.wait_for(proc.wait(), timeout=3.0)
+            if rc == 0:
+                logger.debug("Display :%d ready after %.1fs", display_num, elapsed)
+                return True
+        except (TimeoutError, OSError):
+            pass
+        await asyncio.sleep(interval)
+        elapsed += interval
+
+    logger.warning(
+        "Display :%d not ready after %.1fs – proceeding anyway",
+        display_num,
+        timeout,
+    )
+    return False
 
 
 # ---------------------------------------------------------------------------
@@ -250,15 +278,15 @@ class GuiScreenshotTool(BaseTool):
                     )
                 )
 
+            max_size = settings.GUI_MAX_SCREENSHOT_SIZE_MB
             file_size_mb = image_path.stat().st_size / (1024 * 1024)
-            if file_size_mb > MAX_SCREENSHOT_SIZE_MB:
+            if file_size_mb > max_size:
                 return self._format_result(
                     GuiScreenshotResult(
                         session_id=session_id,
                         error="FileTooLarge",
                         message=(
-                            f"Screenshot size ({file_size_mb:.2f} MB) exceeds "
-                            f"maximum allowed size ({MAX_SCREENSHOT_SIZE_MB} MB)."
+                            f"Screenshot size ({file_size_mb:.2f} MB) exceeds maximum allowed size ({max_size} MB)."
                         ),
                     )
                 )
@@ -405,7 +433,7 @@ class GuiScreenshotTool(BaseTool):
             xvfb_proc.pid,
         )
 
-        # Wait for Qt / OpenGL to finish initialising
-        await asyncio.sleep(_GUI_INIT_SLEEP)
+        # Wait for the X11 display to become ready (replaces fixed sleep)
+        await _wait_for_display(display_num)
 
         return session_id

--- a/src/openroad_mcp/tools/gui.py
+++ b/src/openroad_mcp/tools/gui.py
@@ -1,0 +1,209 @@
+"""GUI screenshot tool for headless OpenROAD GUI sessions."""
+
+import asyncio
+import base64
+import shutil
+import tempfile
+import uuid
+from datetime import datetime
+from pathlib import Path
+
+from ..core.models import GuiScreenshotResult
+from ..interactive.models import SessionError, SessionNotFoundError, SessionTerminatedError
+from ..utils.logging import get_logger
+from .base import BaseTool
+
+logger = get_logger("gui_tools")
+
+# Default virtual framebuffer geometry
+DEFAULT_DISPLAY_RESOLUTION = "1280x1024x24"
+
+# Timeout for GUI startup and image capture (ms)
+GUI_STARTUP_TIMEOUT_MS = 10_000
+IMAGE_CAPTURE_TIMEOUT_MS = 8_000
+
+# Maximum screenshot file size (MB)
+MAX_SCREENSHOT_SIZE_MB = 50
+
+# Tcl template: open the GUI, wait for rendering, save the image, then continue
+# The `after` callbacks give the GUI event loop time to render before capture.
+_SAVE_IMAGE_TCL = 'gui::save_image "{path}"'
+
+# Polling settings for waiting on the screenshot file
+_FILE_POLL_INTERVAL = 0.5  # seconds between polls
+_FILE_POLL_MAX_WAIT = 5.0  # total seconds to wait for non-empty file
+
+
+def _xvfb_available() -> bool:
+    """Check whether xvfb-run is on PATH."""
+    return shutil.which("xvfb-run") is not None
+
+
+class GuiScreenshotTool(BaseTool):
+    """Capture a screenshot from an OpenROAD GUI session running under Xvfb."""
+
+    async def execute(
+        self,
+        session_id: str | None = None,
+        resolution: str | None = None,
+        output_path: str | None = None,
+        timeout_ms: int | None = None,
+    ) -> str:
+        """Take a GUI screenshot.
+
+        Parameters
+        ----------
+        session_id:
+            Existing GUI-enabled session to reuse.  When *None* a fresh
+            ``xvfb-run openroad -gui`` session is created automatically.
+        resolution:
+            Virtual display size, e.g. ``"1920x1080x24"``.
+            Defaults to ``1280x1024x24``.
+        output_path:
+            Where to write the PNG on disk.  A temp file is used when omitted.
+        timeout_ms:
+            How long to wait for the screenshot capture (default 8 000 ms).
+        """
+        actual_timeout = timeout_ms or IMAGE_CAPTURE_TIMEOUT_MS
+        actual_resolution = resolution or DEFAULT_DISPLAY_RESOLUTION
+
+        try:
+            # ----------------------------------------------------------
+            # 1.  Ensure we have a GUI-capable session
+            # ----------------------------------------------------------
+            if session_id is None:
+                if not _xvfb_available():
+                    return self._format_result(
+                        GuiScreenshotResult(
+                            error="XvfbNotFound",
+                            message=("xvfb-run is not installed.  Install it with: apt-get install -y xvfb"),
+                        )
+                    )
+
+                session_id = await self.manager.create_session(
+                    command=[
+                        "xvfb-run",
+                        "-a",  # auto-pick a free display
+                        "-s",
+                        f"-screen 0 {actual_resolution}",
+                        "openroad",
+                        "-gui",
+                        "-no_init",
+                    ],
+                )
+                logger.info("Created headless GUI session %s", session_id)
+
+                # Give the GUI event loop time to initialise
+                await asyncio.sleep(3.0)
+
+            # ----------------------------------------------------------
+            # 2.  Determine output file path
+            # ----------------------------------------------------------
+            if output_path:
+                image_path = Path(output_path)
+            else:
+                # Build a path without pre-creating the file so we can
+                # reliably detect whether gui::save_image wrote anything.
+                tmp_dir = Path(tempfile.gettempdir())
+                tmp_name = f"openroad_gui_{uuid.uuid4().hex[:12]}.png"
+                image_path = tmp_dir / tmp_name
+
+            # Remove any stale file so the existence check is meaningful
+            image_path.unlink(missing_ok=True)
+
+            # ----------------------------------------------------------
+            # 3.  Ask OpenROAD to save the current view
+            # ----------------------------------------------------------
+            save_cmd = _SAVE_IMAGE_TCL.format(path=image_path)
+            result = await self.manager.execute_command(
+                session_id,
+                save_cmd,
+                actual_timeout,
+            )
+
+            # ----------------------------------------------------------
+            # 3b. Poll until the file appears with non-zero content.
+            #     gui::save_image may need several event-loop ticks to
+            #     render the frame buffer and flush the PNG to disk.
+            # ----------------------------------------------------------
+            elapsed = 0.0
+            while elapsed < _FILE_POLL_MAX_WAIT:
+                if image_path.exists() and image_path.stat().st_size > 0:
+                    break
+                await asyncio.sleep(_FILE_POLL_INTERVAL)
+                elapsed += _FILE_POLL_INTERVAL
+
+            # ----------------------------------------------------------
+            # 4.  Read the image and return base64-encoded data
+            # ----------------------------------------------------------
+            if not image_path.exists() or image_path.stat().st_size == 0:
+                return self._format_result(
+                    GuiScreenshotResult(
+                        session_id=session_id,
+                        error="ScreenshotFailed",
+                        message=(
+                            f"Screenshot file was not created (or is empty) at {image_path}.  "
+                            "The GUI may not have finished rendering yet.  "
+                            f"OpenROAD output: {result.output[:500]}"
+                        ),
+                    )
+                )
+
+            file_size_mb = image_path.stat().st_size / (1024 * 1024)
+            if file_size_mb > MAX_SCREENSHOT_SIZE_MB:
+                return self._format_result(
+                    GuiScreenshotResult(
+                        session_id=session_id,
+                        error="FileTooLarge",
+                        message=(
+                            f"Screenshot size ({file_size_mb:.2f} MB) exceeds "
+                            f"maximum allowed size ({MAX_SCREENSHOT_SIZE_MB} MB)."
+                        ),
+                    )
+                )
+
+            image_data = image_path.read_bytes()
+            image_b64 = base64.b64encode(image_data).decode("utf-8")
+
+            return self._format_result(
+                GuiScreenshotResult(
+                    session_id=session_id,
+                    image_data=image_b64,
+                    image_path=str(image_path),
+                    image_format="png",
+                    size_bytes=len(image_data),
+                    resolution=actual_resolution,
+                    timestamp=datetime.now().isoformat(),
+                    message="Screenshot captured successfully.",
+                )
+            )
+
+        except SessionNotFoundError as e:
+            logger.warning("GUI session not found: %s", session_id)
+            return self._format_result(
+                GuiScreenshotResult(
+                    session_id=session_id,
+                    error="SessionNotFound",
+                    message=str(e),
+                )
+            )
+
+        except (SessionTerminatedError, SessionError) as e:
+            logger.error("GUI session error for %s: %s", session_id, e)
+            return self._format_result(
+                GuiScreenshotResult(
+                    session_id=session_id,
+                    error="SessionError",
+                    message=str(e),
+                )
+            )
+
+        except Exception as e:
+            logger.exception("Unexpected error capturing GUI screenshot")
+            return self._format_result(
+                GuiScreenshotResult(
+                    session_id=session_id,
+                    error="UnexpectedError",
+                    message=f"Failed to capture GUI screenshot: {e}",
+                )
+            )

--- a/src/openroad_mcp/tools/gui.py
+++ b/src/openroad_mcp/tools/gui.py
@@ -281,8 +281,31 @@ class GuiScreenshotTool(BaseTool):
             * ``"path"``  – file path only, no image data (saves tokens)
             * ``"preview"`` – 256 px thumbnail as base-64 + file path
         """
+        # ---- Normalise inputs ----
+        # MCP Inspector / FastMCP may pass empty strings for optional
+        # parameters the user left blank.  Treat "" the same as None.
+        if not image_format:  # None or ""
+            image_format = None
+        if not return_mode:
+            return_mode = None
+        if not resolution:
+            resolution = None
+        if not output_path:
+            output_path = None
+        if not crop:
+            crop = None
+
         actual_timeout = timeout_ms or settings.GUI_CAPTURE_TIMEOUT_MS
         actual_resolution = resolution or settings.GUI_DISPLAY_RESOLUTION
+
+        # If the user did not specify image_format but provided an output_path
+        # with a recognised extension, infer the format from the path.
+        _ext_to_fmt: dict[str, str] = {".jpg": "jpeg", ".jpeg": "jpeg", ".png": "png", ".webp": "webp"}
+        if image_format is None and output_path:
+            inferred = _ext_to_fmt.get(Path(output_path).suffix.lower())
+            if inferred:
+                image_format = inferred
+
         fmt = (image_format or settings.GUI_DEFAULT_IMAGE_FORMAT).lower()
         actual_quality = quality if quality is not None else settings.GUI_DEFAULT_JPEG_QUALITY
         actual_scale = scale if scale is not None else 1.0
@@ -480,6 +503,13 @@ class GuiScreenshotTool(BaseTool):
             ext_map = {"jpeg": ".jpg", "png": ".png", "webp": ".webp"}
             if output_path:
                 final_path = Path(output_path)
+                # Ensure the correct extension matches the requested format
+                expected_ext = ext_map[fmt]
+                if final_path.suffix.lower() not in (expected_ext, expected_ext.replace(".", "")):
+                    # Append or replace extension to match format
+                    final_path = final_path.with_suffix(expected_ext)
+                # Create parent directories if they don't exist
+                final_path.parent.mkdir(parents=True, exist_ok=True)
             else:
                 final_name = f"openroad_gui_{uuid.uuid4().hex[:12]}{ext_map[fmt]}"
                 final_path = tmp_dir / final_name

--- a/src/openroad_mcp/tools/gui.py
+++ b/src/openroad_mcp/tools/gui.py
@@ -580,34 +580,39 @@ class GuiScreenshotTool(BaseTool):
                 )
 
             if mode == "preview":
-                # Generate a small thumbnail for preview
+                # Generate a small thumbnail for preview and save it to disk
                 preview_img: Image.Image = Image.open(io.BytesIO(processed_bytes))
                 preview_img.thumbnail((_PREVIEW_SIZE, _PREVIEW_SIZE), Image.Resampling.LANCZOS)
+                preview_w, preview_h = preview_img.size
                 preview_buf = io.BytesIO()
                 if fmt == "jpeg" and preview_img.mode in ("RGBA", "LA", "PA"):
                     preview_img = preview_img.convert("RGB")
                 preview_img.save(preview_buf, format=pil_fmt, **save_kwargs)
                 preview_img.close()
-                preview_b64 = base64.b64encode(preview_buf.getvalue()).decode("utf-8")
+                preview_bytes = preview_buf.getvalue()
+
+                # Overwrite the full-size file with the thumbnail
+                final_path.write_bytes(preview_bytes)
+
+                preview_b64 = base64.b64encode(preview_bytes).decode("utf-8")
                 return self._format_result(
                     GuiScreenshotResult(
                         session_id=session_id,
                         image_data=preview_b64,
                         image_path=str(final_path),
                         image_format=fmt,
-                        size_bytes=processed_size,
+                        size_bytes=len(preview_bytes),
                         original_size_bytes=original_size,
-                        resolution=actual_resolution,
+                        resolution=f"{preview_w}x{preview_h}",
                         timestamp=now,
                         return_mode=mode,
-                        compression_applied=compression_applied,
-                        compression_ratio=compression_ratio,
-                        width=final_w,
-                        height=final_h,
+                        compression_applied=True,
+                        compression_ratio=len(preview_bytes) / original_size if original_size > 0 else None,
+                        width=preview_w,
+                        height=preview_h,
                         message=(
-                            f"Preview thumbnail ({_PREVIEW_SIZE}px) returned. "
-                            f"Full image at {final_path} "
-                            f"({processed_size:,} bytes, {fmt})."
+                            f"Preview thumbnail ({preview_w}x{preview_h}) saved to {final_path} "
+                            f"({len(preview_bytes):,} bytes, {fmt})."
                         ),
                     )
                 )

--- a/src/openroad_mcp/tools/gui.py
+++ b/src/openroad_mcp/tools/gui.py
@@ -46,6 +46,9 @@ from .base import BaseTool
 
 logger = get_logger("gui_tools")
 
+# Module-level lock to prevent concurrent display allocation races
+_display_lock = asyncio.Lock()
+
 # ---------------------------------------------------------------------------
 # Derived constants – computed once from centralised settings.
 # Module-level names kept for backward compatibility and test imports.
@@ -127,6 +130,7 @@ async def _wait_for_display(display_num: int) -> bool:
     elapsed = 0.0
 
     while elapsed < timeout:
+        proc = None
         try:
             proc = await asyncio.create_subprocess_exec(
                 "xdpyinfo",
@@ -138,7 +142,11 @@ async def _wait_for_display(display_num: int) -> bool:
             if rc == 0:
                 logger.debug("Display :%d ready after %.1fs", display_num, elapsed)
                 return True
-        except (TimeoutError, OSError):
+        except TimeoutError:
+            if proc is not None:
+                proc.kill()
+                await proc.wait()
+        except OSError:
             pass
         await asyncio.sleep(interval)
         elapsed += interval
@@ -167,6 +175,7 @@ async def _wait_for_gui_ready(display_num: int) -> bool:
     elapsed = 0.0
 
     while elapsed < timeout:
+        proc = None
         try:
             proc = await asyncio.create_subprocess_exec(
                 "xwininfo",
@@ -196,7 +205,11 @@ async def _wait_for_gui_ready(display_num: int) -> bool:
                         len(child_lines),
                     )
                     return True
-        except (TimeoutError, OSError):
+        except TimeoutError:
+            if proc is not None:
+                proc.kill()
+                await proc.wait()
+        except OSError:
             pass
         await asyncio.sleep(interval)
         elapsed += interval
@@ -707,20 +720,21 @@ class GuiScreenshotTool(BaseTool):
             )
 
         # --- Start Xvfb on a free display ---
-        display_num = _find_free_display()
+        async with _display_lock:
+            display_num = _find_free_display()
 
-        xvfb_proc = await asyncio.create_subprocess_exec(
-            "Xvfb",
-            f":{display_num}",
-            "-screen",
-            "0",
-            resolution,
-            stdout=asyncio.subprocess.DEVNULL,
-            stderr=asyncio.subprocess.DEVNULL,
-        )
+            xvfb_proc = await asyncio.create_subprocess_exec(
+                "Xvfb",
+                f":{display_num}",
+                "-screen",
+                "0",
+                resolution,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
 
-        # Give Xvfb a moment to bind the display socket
-        await asyncio.sleep(settings.GUI_XVFB_SETTLE_S)
+            # Give Xvfb a moment to bind the display socket
+            await asyncio.sleep(settings.GUI_XVFB_SETTLE_S)
 
         # Check that Xvfb is still running
         if xvfb_proc.returncode is not None:
@@ -732,10 +746,15 @@ class GuiScreenshotTool(BaseTool):
             )
 
         # --- Start OpenROAD on that display ---
-        session_id = await self.manager.create_session(
-            command=[openroad_exe, "-gui", "-no_init"],
-            env={"DISPLAY": f":{display_num}"},
-        )
+        try:
+            session_id = await self.manager.create_session(
+                command=[openroad_exe, "-gui", "-no_init"],
+                env={"DISPLAY": f":{display_num}"},
+            )
+        except Exception:
+            xvfb_proc.terminate()
+            await xvfb_proc.wait()
+            raise
 
         self._session_displays[session_id] = display_num
         self._xvfb_pids[session_id] = xvfb_proc.pid

--- a/src/openroad_mcp/tools/gui.py
+++ b/src/openroad_mcp/tools/gui.py
@@ -282,18 +282,32 @@ class GuiScreenshotTool(BaseTool):
             * ``"preview"`` – 256 px thumbnail as base-64 + file path
         """
         # ---- Normalise inputs ----
-        # MCP Inspector / FastMCP may pass empty strings for optional
-        # parameters the user left blank.  Treat "" the same as None.
-        if not image_format:  # None or ""
-            image_format = None
-        if not return_mode:
-            return_mode = None
-        if not resolution:
-            resolution = None
-        if not output_path:
-            output_path = None
-        if not crop:
-            crop = None
+        # MCP Inspector / FastMCP may pass empty strings or whitespace-
+        # padded values for optional parameters.  Strip and convert to
+        # None when empty so downstream defaults work correctly.
+        image_format = image_format.strip() if image_format else None
+        image_format = image_format or None
+        return_mode = return_mode.strip() if return_mode else None
+        return_mode = return_mode or None
+        resolution = resolution.strip() if resolution else None
+        resolution = resolution or None
+        output_path = output_path.strip() if output_path else None
+        output_path = output_path or None
+        crop = crop.strip() if crop else None
+        crop = crop or None
+
+        logger.debug(
+            "gui_screenshot params: session_id=%s resolution=%s output_path=%s "
+            "image_format=%s quality=%s scale=%s crop=%s return_mode=%s",
+            session_id,
+            resolution,
+            output_path,
+            image_format,
+            quality,
+            scale,
+            crop,
+            return_mode,
+        )
 
         actual_timeout = timeout_ms or settings.GUI_CAPTURE_TIMEOUT_MS
         actual_resolution = resolution or settings.GUI_DISPLAY_RESOLUTION
@@ -437,7 +451,7 @@ class GuiScreenshotTool(BaseTool):
             # Crop (pixel coordinates: "x0 y0 x1 y1")
             if crop:
                 try:
-                    coords = tuple(int(c) for c in crop.split())
+                    coords = tuple(int(c) for c in crop.replace(",", " ").split())
                     if len(coords) != 4:
                         raise ValueError("Expected 4 integers")
                     img = img.crop(coords)
@@ -449,7 +463,7 @@ class GuiScreenshotTool(BaseTool):
                             error="InvalidParameter",
                             message=(
                                 f"Invalid crop value '{crop}'. "
-                                "Expected 4 space-separated pixel coordinates: 'x0 y0 x1 y1'. "
+                                "Expected 4 pixel coordinates: 'x0,y0,x1,y1' or 'x0 y0 x1 y1'. "
                                 f"Error: {e}"
                             ),
                         )
@@ -501,13 +515,17 @@ class GuiScreenshotTool(BaseTool):
             # 6.  Write final file & build result
             # ----------------------------------------------------------
             ext_map = {"jpeg": ".jpg", "png": ".png", "webp": ".webp"}
+            # All extensions that are valid for each format
+            _valid_exts: dict[str, set[str]] = {
+                "jpeg": {".jpg", ".jpeg"},
+                "png": {".png"},
+                "webp": {".webp"},
+            }
             if output_path:
                 final_path = Path(output_path)
-                # Ensure the correct extension matches the requested format
-                expected_ext = ext_map[fmt]
-                if final_path.suffix.lower() not in (expected_ext, expected_ext.replace(".", "")):
-                    # Append or replace extension to match format
-                    final_path = final_path.with_suffix(expected_ext)
+                # Correct the extension if it doesn't match the format
+                if final_path.suffix.lower() not in _valid_exts.get(fmt, set()):
+                    final_path = final_path.with_suffix(ext_map[fmt])
                 # Create parent directories if they don't exist
                 final_path.parent.mkdir(parents=True, exist_ok=True)
             else:

--- a/src/openroad_mcp/tools/gui.py
+++ b/src/openroad_mcp/tools/gui.py
@@ -113,7 +113,7 @@ def _find_free_display() -> int:
         if not lock.exists():
             return num
     # Fallback – use a high random number outside the configured range
-    return start + uuid.uuid4().int % settings.GUI_DISPLAY_FALLBACK_RANGE
+    return end + uuid.uuid4().int % settings.GUI_DISPLAY_FALLBACK_RANGE
 
 
 async def _wait_for_display(display_num: int) -> bool:
@@ -401,169 +401,228 @@ class GuiScreenshotTool(BaseTool):
             raw_path = tmp_dir / raw_name
             raw_path.unlink(missing_ok=True)
 
-            # ----------------------------------------------------------
-            # 3.  Capture the X11 root window via ImageMagick import
-            # ----------------------------------------------------------
-            display_env = {**os.environ, "DISPLAY": f":{display_num}"}
-            import_timeout = actual_timeout / 1000.0
-
-            proc = await asyncio.create_subprocess_exec(
-                "import",
-                "-window",
-                "root",
-                str(raw_path),
-                env=display_env,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            )
-
             try:
-                stdout, stderr = await asyncio.wait_for(
-                    proc.communicate(),
-                    timeout=import_timeout,
-                )
-            except TimeoutError:
-                proc.kill()
-                return self._format_result(
-                    GuiScreenshotResult(
-                        session_id=session_id,
-                        error="ScreenshotFailed",
-                        message=(
-                            f"ImageMagick import timed out after {import_timeout:.0f}s.  "
-                            "The Xvfb display may not be responding."
-                        ),
-                    )
-                )
+                # ----------------------------------------------------------
+                # 3.  Capture the X11 root window via ImageMagick import
+                # ----------------------------------------------------------
+                display_env = {**os.environ, "DISPLAY": f":{display_num}"}
+                import_timeout = actual_timeout / 1000.0
 
-            if proc.returncode != 0:
-                err_text = stderr.decode("utf-8", errors="replace")[: settings.GUI_ERROR_TRUNCATE_CHARS]
-                return self._format_result(
-                    GuiScreenshotResult(
-                        session_id=session_id,
-                        error="ScreenshotFailed",
-                        message=f"ImageMagick import failed (rc={proc.returncode}): {err_text}",
-                    )
+                proc = await asyncio.create_subprocess_exec(
+                    "import",
+                    "-window",
+                    "root",
+                    str(raw_path),
+                    env=display_env,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
                 )
 
-            if not raw_path.exists() or raw_path.stat().st_size == 0:
-                return self._format_result(
-                    GuiScreenshotResult(
-                        session_id=session_id,
-                        error="ScreenshotFailed",
-                        message=f"Screenshot file was not created at {raw_path}.",
-                    )
-                )
-
-            original_size = raw_path.stat().st_size
-
-            # ----------------------------------------------------------
-            # 4.  Post-process: crop → scale → format conversion
-            # ----------------------------------------------------------
-            img: Image.Image = Image.open(raw_path)
-
-            # Crop (pixel coordinates: "x0 y0 x1 y1")
-            if crop:
                 try:
-                    coords = tuple(int(c) for c in crop.replace(",", " ").split())
-                    if len(coords) != 4:
-                        raise ValueError("Expected 4 integers")
-                    img = img.crop(coords)
-                except (ValueError, TypeError) as e:
-                    img.close()
+                    stdout, stderr = await asyncio.wait_for(
+                        proc.communicate(),
+                        timeout=import_timeout,
+                    )
+                except TimeoutError:
+                    proc.kill()
                     return self._format_result(
                         GuiScreenshotResult(
                             session_id=session_id,
-                            error="InvalidParameter",
+                            error="ScreenshotFailed",
                             message=(
-                                f"Invalid crop value '{crop}'. "
-                                "Expected 4 pixel coordinates: 'x0,y0,x1,y1' or 'x0 y0 x1 y1'. "
-                                f"Error: {e}"
+                                f"ImageMagick import timed out after {import_timeout:.0f}s.  "
+                                "The Xvfb display may not be responding."
                             ),
                         )
                     )
 
-            # Scale
-            if actual_scale < 1.0:
-                new_w = max(int(img.width * actual_scale), 1)
-                new_h = max(int(img.height * actual_scale), 1)
-                img = img.resize((new_w, new_h), Image.Resampling.LANCZOS)
-
-            final_w, final_h = img.size
-
-            # Convert to output format in-memory
-            pil_format_map = {"jpeg": "JPEG", "png": "PNG", "webp": "WEBP"}
-            pil_fmt = pil_format_map[fmt]
-
-            # JPEG doesn't support alpha — convert RGBA → RGB
-            if fmt == "jpeg" and img.mode in ("RGBA", "LA", "PA"):
-                img = img.convert("RGB")
-
-            buf = io.BytesIO()
-            save_kwargs: dict[str, int] = {}
-            if fmt in ("jpeg", "webp"):
-                save_kwargs["quality"] = actual_quality
-            img.save(buf, format=pil_fmt, **save_kwargs)
-            img.close()
-
-            processed_bytes = buf.getvalue()
-            processed_size = len(processed_bytes)
-
-            # ----------------------------------------------------------
-            # 5.  File size check
-            # ----------------------------------------------------------
-            max_size = settings.GUI_MAX_SCREENSHOT_SIZE_MB
-            file_size_mb = processed_size / (1024 * 1024)
-            if file_size_mb > max_size:
-                return self._format_result(
-                    GuiScreenshotResult(
-                        session_id=session_id,
-                        error="FileTooLarge",
-                        message=(
-                            f"Screenshot size ({file_size_mb:.2f} MB) exceeds maximum allowed size ({max_size} MB)."
-                        ),
+                if proc.returncode != 0:
+                    err_text = stderr.decode("utf-8", errors="replace")[: settings.GUI_ERROR_TRUNCATE_CHARS]
+                    return self._format_result(
+                        GuiScreenshotResult(
+                            session_id=session_id,
+                            error="ScreenshotFailed",
+                            message=f"ImageMagick import failed (rc={proc.returncode}): {err_text}",
+                        )
                     )
+
+                if not raw_path.exists() or raw_path.stat().st_size == 0:
+                    return self._format_result(
+                        GuiScreenshotResult(
+                            session_id=session_id,
+                            error="ScreenshotFailed",
+                            message=f"Screenshot file was not created at {raw_path}.",
+                        )
+                    )
+
+                original_size = raw_path.stat().st_size
+
+                # ----------------------------------------------------------
+                # 4.  Post-process: crop → scale → format conversion
+                # ----------------------------------------------------------
+                img: Image.Image = Image.open(raw_path)
+
+                # Crop (pixel coordinates: "x0 y0 x1 y1")
+                if crop:
+                    try:
+                        coords = tuple(int(c) for c in crop.replace(",", " ").split())
+                        if len(coords) != 4:
+                            raise ValueError("Expected 4 integers")
+                        img = img.crop(coords)
+                    except (ValueError, TypeError) as e:
+                        img.close()
+                        return self._format_result(
+                            GuiScreenshotResult(
+                                session_id=session_id,
+                                error="InvalidParameter",
+                                message=(
+                                    f"Invalid crop value '{crop}'. "
+                                    "Expected 4 pixel coordinates: 'x0,y0,x1,y1' or 'x0 y0 x1 y1'. "
+                                    f"Error: {e}"
+                                ),
+                            )
+                        )
+
+                # Scale
+                if actual_scale < 1.0:
+                    new_w = max(int(img.width * actual_scale), 1)
+                    new_h = max(int(img.height * actual_scale), 1)
+                    img = img.resize((new_w, new_h), Image.Resampling.LANCZOS)
+
+                final_w, final_h = img.size
+
+                # Convert to output format in-memory
+                pil_format_map = {"jpeg": "JPEG", "png": "PNG", "webp": "WEBP"}
+                pil_fmt = pil_format_map[fmt]
+
+                # JPEG doesn't support alpha — convert RGBA → RGB
+                if fmt == "jpeg" and img.mode in ("RGBA", "LA", "PA"):
+                    img = img.convert("RGB")
+
+                buf = io.BytesIO()
+                save_kwargs: dict[str, int] = {}
+                if fmt in ("jpeg", "webp"):
+                    save_kwargs["quality"] = actual_quality
+                img.save(buf, format=pil_fmt, **save_kwargs)
+                img.close()
+
+                processed_bytes = buf.getvalue()
+                processed_size = len(processed_bytes)
+
+                # ----------------------------------------------------------
+                # 5.  File size check
+                # ----------------------------------------------------------
+                max_size = settings.GUI_MAX_SCREENSHOT_SIZE_MB
+                file_size_mb = processed_size / (1024 * 1024)
+                if file_size_mb > max_size:
+                    return self._format_result(
+                        GuiScreenshotResult(
+                            session_id=session_id,
+                            error="FileTooLarge",
+                            message=(
+                                f"Screenshot size ({file_size_mb:.2f} MB) exceeds maximum allowed size ({max_size} MB)."
+                            ),
+                        )
+                    )
+
+                # ----------------------------------------------------------
+                # 6.  Write final file & build result
+                # ----------------------------------------------------------
+                ext_map = {"jpeg": ".jpg", "png": ".png", "webp": ".webp"}
+                # All extensions that are valid for each format
+                _valid_exts: dict[str, set[str]] = {
+                    "jpeg": {".jpg", ".jpeg"},
+                    "png": {".png"},
+                    "webp": {".webp"},
+                }
+                if output_path:
+                    final_path = Path(output_path)
+                    # If output_path is an existing directory (or ends with /),
+                    # generate a default filename inside it.
+                    if final_path.is_dir() or output_path.endswith("/"):
+                        final_path.mkdir(parents=True, exist_ok=True)
+                        default_name = f"openroad_gui_{uuid.uuid4().hex[: settings.GUI_TEMP_UUID_LENGTH]}{ext_map[fmt]}"
+                        final_path = final_path / default_name
+                    # Correct the extension if it doesn't match the format
+                    elif final_path.suffix.lower() not in _valid_exts.get(fmt, set()):
+                        final_path = final_path.with_suffix(ext_map[fmt])
+                    # Create parent directories if they don't exist
+                    final_path.parent.mkdir(parents=True, exist_ok=True)
+                else:
+                    final_name = f"openroad_gui_{uuid.uuid4().hex[: settings.GUI_TEMP_UUID_LENGTH]}{ext_map[fmt]}"
+                    final_path = tmp_dir / final_name
+
+                final_path.write_bytes(processed_bytes)
+
+                compression_applied = fmt != "png" or actual_scale < 1.0 or crop is not None
+                compression_ratio = (
+                    processed_size / original_size if compression_applied and original_size > 0 else None
                 )
+                now = datetime.now().isoformat()
 
-            # ----------------------------------------------------------
-            # 6.  Write final file & build result
-            # ----------------------------------------------------------
-            ext_map = {"jpeg": ".jpg", "png": ".png", "webp": ".webp"}
-            # All extensions that are valid for each format
-            _valid_exts: dict[str, set[str]] = {
-                "jpeg": {".jpg", ".jpeg"},
-                "png": {".png"},
-                "webp": {".webp"},
-            }
-            if output_path:
-                final_path = Path(output_path)
-                # If output_path is an existing directory (or ends with /),
-                # generate a default filename inside it.
-                if final_path.is_dir() or output_path.endswith("/"):
-                    final_path.mkdir(parents=True, exist_ok=True)
-                    default_name = f"openroad_gui_{uuid.uuid4().hex[: settings.GUI_TEMP_UUID_LENGTH]}{ext_map[fmt]}"
-                    final_path = final_path / default_name
-                # Correct the extension if it doesn't match the format
-                elif final_path.suffix.lower() not in _valid_exts.get(fmt, set()):
-                    final_path = final_path.with_suffix(ext_map[fmt])
-                # Create parent directories if they don't exist
-                final_path.parent.mkdir(parents=True, exist_ok=True)
-            else:
-                final_name = f"openroad_gui_{uuid.uuid4().hex[: settings.GUI_TEMP_UUID_LENGTH]}{ext_map[fmt]}"
-                final_path = tmp_dir / final_name
+                if mode == "path":
+                    return self._format_result(
+                        GuiScreenshotResult(
+                            session_id=session_id,
+                            image_path=str(final_path),
+                            image_format=fmt,
+                            size_bytes=processed_size,
+                            original_size_bytes=original_size,
+                            resolution=actual_resolution,
+                            timestamp=now,
+                            return_mode=mode,
+                            compression_applied=compression_applied,
+                            compression_ratio=compression_ratio,
+                            width=final_w,
+                            height=final_h,
+                            message=(f"Screenshot saved to {final_path} ({processed_size:,} bytes, {fmt})."),
+                        )
+                    )
 
-            final_path.write_bytes(processed_bytes)
+                if mode == "preview":
+                    # Generate a small thumbnail for preview and save it to disk
+                    preview_img: Image.Image = Image.open(io.BytesIO(processed_bytes))
+                    preview_img.thumbnail((_PREVIEW_SIZE, _PREVIEW_SIZE), Image.Resampling.LANCZOS)
+                    preview_w, preview_h = preview_img.size
+                    preview_buf = io.BytesIO()
+                    if fmt == "jpeg" and preview_img.mode in ("RGBA", "LA", "PA"):
+                        preview_img = preview_img.convert("RGB")
+                    preview_img.save(preview_buf, format=pil_fmt, **save_kwargs)
+                    preview_img.close()
+                    preview_bytes = preview_buf.getvalue()
 
-            # Clean up raw capture
-            raw_path.unlink(missing_ok=True)
+                    # Overwrite the full-size file with the thumbnail
+                    final_path.write_bytes(preview_bytes)
 
-            compression_applied = fmt != "png" or actual_scale < 1.0 or crop is not None
-            compression_ratio = processed_size / original_size if compression_applied and original_size > 0 else None
-            now = datetime.now().isoformat()
+                    preview_b64 = base64.b64encode(preview_bytes).decode("utf-8")
+                    return self._format_result(
+                        GuiScreenshotResult(
+                            session_id=session_id,
+                            image_data=preview_b64,
+                            image_path=str(final_path),
+                            image_format=fmt,
+                            size_bytes=len(preview_bytes),
+                            original_size_bytes=original_size,
+                            resolution=f"{preview_w}x{preview_h}",
+                            timestamp=now,
+                            return_mode=mode,
+                            compression_applied=True,
+                            compression_ratio=(len(preview_bytes) / original_size if original_size > 0 else None),
+                            width=preview_w,
+                            height=preview_h,
+                            message=(
+                                f"Preview thumbnail ({preview_w}x{preview_h}) saved to {final_path} "
+                                f"({len(preview_bytes):,} bytes, {fmt})."
+                            ),
+                        )
+                    )
 
-            if mode == "path":
+                # mode == "base64"  (default)
+                image_b64 = base64.b64encode(processed_bytes).decode("utf-8")
                 return self._format_result(
                     GuiScreenshotResult(
                         session_id=session_id,
+                        image_data=image_b64,
                         image_path=str(final_path),
                         image_format=fmt,
                         size_bytes=processed_size,
@@ -575,68 +634,12 @@ class GuiScreenshotTool(BaseTool):
                         compression_ratio=compression_ratio,
                         width=final_w,
                         height=final_h,
-                        message=(f"Screenshot saved to {final_path} ({processed_size:,} bytes, {fmt})."),
+                        message="Screenshot captured successfully.",
                     )
                 )
-
-            if mode == "preview":
-                # Generate a small thumbnail for preview and save it to disk
-                preview_img: Image.Image = Image.open(io.BytesIO(processed_bytes))
-                preview_img.thumbnail((_PREVIEW_SIZE, _PREVIEW_SIZE), Image.Resampling.LANCZOS)
-                preview_w, preview_h = preview_img.size
-                preview_buf = io.BytesIO()
-                if fmt == "jpeg" and preview_img.mode in ("RGBA", "LA", "PA"):
-                    preview_img = preview_img.convert("RGB")
-                preview_img.save(preview_buf, format=pil_fmt, **save_kwargs)
-                preview_img.close()
-                preview_bytes = preview_buf.getvalue()
-
-                # Overwrite the full-size file with the thumbnail
-                final_path.write_bytes(preview_bytes)
-
-                preview_b64 = base64.b64encode(preview_bytes).decode("utf-8")
-                return self._format_result(
-                    GuiScreenshotResult(
-                        session_id=session_id,
-                        image_data=preview_b64,
-                        image_path=str(final_path),
-                        image_format=fmt,
-                        size_bytes=len(preview_bytes),
-                        original_size_bytes=original_size,
-                        resolution=f"{preview_w}x{preview_h}",
-                        timestamp=now,
-                        return_mode=mode,
-                        compression_applied=True,
-                        compression_ratio=len(preview_bytes) / original_size if original_size > 0 else None,
-                        width=preview_w,
-                        height=preview_h,
-                        message=(
-                            f"Preview thumbnail ({preview_w}x{preview_h}) saved to {final_path} "
-                            f"({len(preview_bytes):,} bytes, {fmt})."
-                        ),
-                    )
-                )
-
-            # mode == "base64"  (default)
-            image_b64 = base64.b64encode(processed_bytes).decode("utf-8")
-            return self._format_result(
-                GuiScreenshotResult(
-                    session_id=session_id,
-                    image_data=image_b64,
-                    image_path=str(final_path),
-                    image_format=fmt,
-                    size_bytes=processed_size,
-                    original_size_bytes=original_size,
-                    resolution=actual_resolution,
-                    timestamp=now,
-                    return_mode=mode,
-                    compression_applied=compression_applied,
-                    compression_ratio=compression_ratio,
-                    width=final_w,
-                    height=final_h,
-                    message="Screenshot captured successfully.",
-                )
-            )
+            finally:
+                # Always clean up the raw capture file
+                raw_path.unlink(missing_ok=True)
 
         except SessionNotFoundError as e:
             logger.warning("GUI session not found: %s", session_id)

--- a/src/openroad_mcp/tools/gui.py
+++ b/src/openroad_mcp/tools/gui.py
@@ -523,8 +523,14 @@ class GuiScreenshotTool(BaseTool):
             }
             if output_path:
                 final_path = Path(output_path)
+                # If output_path is an existing directory (or ends with /),
+                # generate a default filename inside it.
+                if final_path.is_dir() or output_path.endswith("/"):
+                    final_path.mkdir(parents=True, exist_ok=True)
+                    default_name = f"openroad_gui_{uuid.uuid4().hex[: settings.GUI_TEMP_UUID_LENGTH]}{ext_map[fmt]}"
+                    final_path = final_path / default_name
                 # Correct the extension if it doesn't match the format
-                if final_path.suffix.lower() not in _valid_exts.get(fmt, set()):
+                elif final_path.suffix.lower() not in _valid_exts.get(fmt, set()):
                     final_path = final_path.with_suffix(ext_map[fmt])
                 # Create parent directories if they don't exist
                 final_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/openroad_mcp/tools/gui.py
+++ b/src/openroad_mcp/tools/gui.py
@@ -20,11 +20,13 @@ The lifecycle is:
 3. Poll the display with ``xdpyinfo`` until a window appears (with a
    configurable timeout fallback).
 4. Run ``import -window root <path>`` on the same ``DISPLAY``.
-5. Read the resulting PNG and return it as base-64.
+5. Post-process the raw PNG (crop, scale, format conversion) using
+   Pillow, then return based on the requested ``return_mode``.
 """
 
 import asyncio
 import base64
+import io
 import os
 import shutil
 import signal
@@ -32,6 +34,8 @@ import tempfile
 import uuid
 from datetime import datetime
 from pathlib import Path
+
+from PIL import Image
 
 from ..config.settings import settings
 from ..core.manager import OpenROADManager
@@ -48,6 +52,15 @@ logger = get_logger("gui_tools")
 # ---------------------------------------------------------------------------
 
 MAX_SCREENSHOT_SIZE_MB: int = settings.GUI_MAX_SCREENSHOT_SIZE_MB
+
+# Accepted image output formats
+_VALID_FORMATS = {"png", "jpeg", "webp"}
+
+# Accepted return modes
+_VALID_RETURN_MODES = {"base64", "path", "preview"}
+
+# Preview thumbnail max dimension (longest side)
+_PREVIEW_SIZE = 256
 
 
 # ---------------------------------------------------------------------------
@@ -168,6 +181,11 @@ class GuiScreenshotTool(BaseTool):
         resolution: str | None = None,
         output_path: str | None = None,
         timeout_ms: int | None = None,
+        image_format: str | None = None,
+        quality: int | None = None,
+        scale: float | None = None,
+        crop: str | None = None,
+        return_mode: str | None = None,
     ) -> str:
         """Take a GUI screenshot.
 
@@ -180,12 +198,69 @@ class GuiScreenshotTool(BaseTool):
             Virtual display size, e.g. ``"1920x1080x24"``.
             Defaults to ``1280x1024x24``.
         output_path:
-            Where to write the PNG on disk.  A temp file is used when omitted.
+            Where to write the final image on disk.  A temp file is used
+            when omitted.
         timeout_ms:
             How long to wait for the screenshot capture (default 8 000 ms).
+        image_format:
+            Output format: ``"png"``, ``"jpeg"``, or ``"webp"``.
+            Defaults to ``settings.GUI_DEFAULT_IMAGE_FORMAT``.
+        quality:
+            Compression quality for JPEG/WebP (1–100).
+            Ignored for PNG.  Defaults to
+            ``settings.GUI_DEFAULT_JPEG_QUALITY``.
+        scale:
+            Downscale factor (0.0–1.0].  ``0.5`` produces an image at
+            half the original dimensions.  Defaults to ``1.0`` (no
+            scaling).
+        crop:
+            Pixel region to crop: ``"x0 y0 x1 y1"``.  Applied *before*
+            scaling.  Omit to keep the full image.
+        return_mode:
+            How to return the result:
+
+            * ``"base64"`` – full image as base-64 (default)
+            * ``"path"``  – file path only, no image data (saves tokens)
+            * ``"preview"`` – 256 px thumbnail as base-64 + file path
         """
         actual_timeout = timeout_ms or settings.GUI_CAPTURE_TIMEOUT_MS
         actual_resolution = resolution or settings.GUI_DISPLAY_RESOLUTION
+        fmt = (image_format or settings.GUI_DEFAULT_IMAGE_FORMAT).lower()
+        actual_quality = quality if quality is not None else settings.GUI_DEFAULT_JPEG_QUALITY
+        actual_scale = scale if scale is not None else 1.0
+        mode = (return_mode or "base64").lower()
+
+        # ---- Validate parameters early ----
+        if fmt not in _VALID_FORMATS:
+            return self._format_result(
+                GuiScreenshotResult(
+                    error="InvalidParameter",
+                    message=(f"Unsupported image format '{fmt}'. Choose from: {', '.join(sorted(_VALID_FORMATS))}."),
+                )
+            )
+        if mode not in _VALID_RETURN_MODES:
+            return self._format_result(
+                GuiScreenshotResult(
+                    error="InvalidParameter",
+                    message=(
+                        f"Unsupported return_mode '{mode}'. Choose from: {', '.join(sorted(_VALID_RETURN_MODES))}."
+                    ),
+                )
+            )
+        if not (0.0 < actual_scale <= 1.0):
+            return self._format_result(
+                GuiScreenshotResult(
+                    error="InvalidParameter",
+                    message="scale must be between 0.0 (exclusive) and 1.0 (inclusive).",
+                )
+            )
+        if not (1 <= actual_quality <= 100):
+            return self._format_result(
+                GuiScreenshotResult(
+                    error="InvalidParameter",
+                    message="quality must be between 1 and 100.",
+                )
+            )
 
         try:
             # ----------------------------------------------------------
@@ -211,16 +286,12 @@ class GuiScreenshotTool(BaseTool):
                 )
 
             # ----------------------------------------------------------
-            # 2.  Determine output file path
+            # 2.  Determine raw capture path (always PNG from import)
             # ----------------------------------------------------------
-            if output_path:
-                image_path = Path(output_path)
-            else:
-                tmp_dir = Path(tempfile.gettempdir())
-                tmp_name = f"openroad_gui_{uuid.uuid4().hex[:12]}.png"
-                image_path = tmp_dir / tmp_name
-
-            image_path.unlink(missing_ok=True)
+            tmp_dir = Path(tempfile.gettempdir())
+            raw_name = f"openroad_gui_raw_{uuid.uuid4().hex[:12]}.png"
+            raw_path = tmp_dir / raw_name
+            raw_path.unlink(missing_ok=True)
 
             # ----------------------------------------------------------
             # 3.  Capture the X11 root window via ImageMagick import
@@ -232,7 +303,7 @@ class GuiScreenshotTool(BaseTool):
                 "import",
                 "-window",
                 "root",
-                str(image_path),
+                str(raw_path),
                 env=display_env,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
@@ -266,20 +337,74 @@ class GuiScreenshotTool(BaseTool):
                     )
                 )
 
-            # ----------------------------------------------------------
-            # 4.  Validate & return the captured image
-            # ----------------------------------------------------------
-            if not image_path.exists() or image_path.stat().st_size == 0:
+            if not raw_path.exists() or raw_path.stat().st_size == 0:
                 return self._format_result(
                     GuiScreenshotResult(
                         session_id=session_id,
                         error="ScreenshotFailed",
-                        message=f"Screenshot file was not created at {image_path}.",
+                        message=f"Screenshot file was not created at {raw_path}.",
                     )
                 )
 
+            original_size = raw_path.stat().st_size
+
+            # ----------------------------------------------------------
+            # 4.  Post-process: crop → scale → format conversion
+            # ----------------------------------------------------------
+            img: Image.Image = Image.open(raw_path)
+
+            # Crop (pixel coordinates: "x0 y0 x1 y1")
+            if crop:
+                try:
+                    coords = tuple(int(c) for c in crop.split())
+                    if len(coords) != 4:
+                        raise ValueError("Expected 4 integers")
+                    img = img.crop(coords)
+                except (ValueError, TypeError) as e:
+                    img.close()
+                    return self._format_result(
+                        GuiScreenshotResult(
+                            session_id=session_id,
+                            error="InvalidParameter",
+                            message=(
+                                f"Invalid crop value '{crop}'. "
+                                "Expected 4 space-separated pixel coordinates: 'x0 y0 x1 y1'. "
+                                f"Error: {e}"
+                            ),
+                        )
+                    )
+
+            # Scale
+            if actual_scale < 1.0:
+                new_w = max(int(img.width * actual_scale), 1)
+                new_h = max(int(img.height * actual_scale), 1)
+                img = img.resize((new_w, new_h), Image.Resampling.LANCZOS)
+
+            final_w, final_h = img.size
+
+            # Convert to output format in-memory
+            pil_format_map = {"jpeg": "JPEG", "png": "PNG", "webp": "WEBP"}
+            pil_fmt = pil_format_map[fmt]
+
+            # JPEG doesn't support alpha — convert RGBA → RGB
+            if fmt == "jpeg" and img.mode in ("RGBA", "LA", "PA"):
+                img = img.convert("RGB")
+
+            buf = io.BytesIO()
+            save_kwargs: dict[str, int] = {}
+            if fmt in ("jpeg", "webp"):
+                save_kwargs["quality"] = actual_quality
+            img.save(buf, format=pil_fmt, **save_kwargs)
+            img.close()
+
+            processed_bytes = buf.getvalue()
+            processed_size = len(processed_bytes)
+
+            # ----------------------------------------------------------
+            # 5.  File size check
+            # ----------------------------------------------------------
             max_size = settings.GUI_MAX_SCREENSHOT_SIZE_MB
-            file_size_mb = image_path.stat().st_size / (1024 * 1024)
+            file_size_mb = processed_size / (1024 * 1024)
             if file_size_mb > max_size:
                 return self._format_result(
                     GuiScreenshotResult(
@@ -291,18 +416,94 @@ class GuiScreenshotTool(BaseTool):
                     )
                 )
 
-            image_data = image_path.read_bytes()
-            image_b64 = base64.b64encode(image_data).decode("utf-8")
+            # ----------------------------------------------------------
+            # 6.  Write final file & build result
+            # ----------------------------------------------------------
+            ext_map = {"jpeg": ".jpg", "png": ".png", "webp": ".webp"}
+            if output_path:
+                final_path = Path(output_path)
+            else:
+                final_name = f"openroad_gui_{uuid.uuid4().hex[:12]}{ext_map[fmt]}"
+                final_path = tmp_dir / final_name
 
+            final_path.write_bytes(processed_bytes)
+
+            # Clean up raw capture
+            raw_path.unlink(missing_ok=True)
+
+            compression_applied = fmt != "png" or actual_scale < 1.0 or crop is not None
+            compression_ratio = processed_size / original_size if compression_applied and original_size > 0 else None
+            now = datetime.now().isoformat()
+
+            if mode == "path":
+                return self._format_result(
+                    GuiScreenshotResult(
+                        session_id=session_id,
+                        image_path=str(final_path),
+                        image_format=fmt,
+                        size_bytes=processed_size,
+                        original_size_bytes=original_size,
+                        resolution=actual_resolution,
+                        timestamp=now,
+                        return_mode=mode,
+                        compression_applied=compression_applied,
+                        compression_ratio=compression_ratio,
+                        width=final_w,
+                        height=final_h,
+                        message=(f"Screenshot saved to {final_path} ({processed_size:,} bytes, {fmt})."),
+                    )
+                )
+
+            if mode == "preview":
+                # Generate a small thumbnail for preview
+                preview_img: Image.Image = Image.open(io.BytesIO(processed_bytes))
+                preview_img.thumbnail((_PREVIEW_SIZE, _PREVIEW_SIZE), Image.Resampling.LANCZOS)
+                preview_buf = io.BytesIO()
+                if fmt == "jpeg" and preview_img.mode in ("RGBA", "LA", "PA"):
+                    preview_img = preview_img.convert("RGB")
+                preview_img.save(preview_buf, format=pil_fmt, **save_kwargs)
+                preview_img.close()
+                preview_b64 = base64.b64encode(preview_buf.getvalue()).decode("utf-8")
+                return self._format_result(
+                    GuiScreenshotResult(
+                        session_id=session_id,
+                        image_data=preview_b64,
+                        image_path=str(final_path),
+                        image_format=fmt,
+                        size_bytes=processed_size,
+                        original_size_bytes=original_size,
+                        resolution=actual_resolution,
+                        timestamp=now,
+                        return_mode=mode,
+                        compression_applied=compression_applied,
+                        compression_ratio=compression_ratio,
+                        width=final_w,
+                        height=final_h,
+                        message=(
+                            f"Preview thumbnail ({_PREVIEW_SIZE}px) returned. "
+                            f"Full image at {final_path} "
+                            f"({processed_size:,} bytes, {fmt})."
+                        ),
+                    )
+                )
+
+            # mode == "base64"  (default)
+            image_b64 = base64.b64encode(processed_bytes).decode("utf-8")
             return self._format_result(
                 GuiScreenshotResult(
                     session_id=session_id,
                     image_data=image_b64,
-                    image_path=str(image_path),
-                    image_format="png",
-                    size_bytes=len(image_data),
+                    image_path=str(final_path),
+                    image_format=fmt,
+                    size_bytes=processed_size,
+                    original_size_bytes=original_size,
                     resolution=actual_resolution,
-                    timestamp=datetime.now().isoformat(),
+                    timestamp=now,
+                    return_mode=mode,
+                    compression_applied=compression_applied,
+                    compression_ratio=compression_ratio,
+                    width=final_w,
+                    height=final_h,
                     message="Screenshot captured successfully.",
                 )
             )

--- a/src/openroad_mcp/tools/gui.py
+++ b/src/openroad_mcp/tools/gui.py
@@ -32,6 +32,7 @@ import uuid
 from datetime import datetime
 from pathlib import Path
 
+from ..config.settings import settings
 from ..core.manager import OpenROADManager
 from ..core.models import GuiScreenshotResult
 from ..interactive.models import SessionError, SessionNotFoundError, SessionTerminatedError
@@ -44,12 +45,8 @@ logger = get_logger("gui_tools")
 # Constants
 # ---------------------------------------------------------------------------
 
-# Default virtual framebuffer geometry  (WxHxDepth)
-DEFAULT_DISPLAY_RESOLUTION = "1280x1024x24"
-
 # Timeout defaults (ms)
 GUI_STARTUP_TIMEOUT_MS = 10_000
-IMAGE_CAPTURE_TIMEOUT_MS = 8_000
 
 # Maximum screenshot file size (MB)
 MAX_SCREENSHOT_SIZE_MB = 50
@@ -159,8 +156,8 @@ class GuiScreenshotTool(BaseTool):
         timeout_ms:
             How long to wait for the screenshot capture (default 8 000 ms).
         """
-        actual_timeout = timeout_ms or IMAGE_CAPTURE_TIMEOUT_MS
-        actual_resolution = resolution or DEFAULT_DISPLAY_RESOLUTION
+        actual_timeout = timeout_ms or settings.GUI_CAPTURE_TIMEOUT_MS
+        actual_resolution = resolution or settings.GUI_DISPLAY_RESOLUTION
 
         try:
             # ----------------------------------------------------------

--- a/src/openroad_mcp/tools/gui.py
+++ b/src/openroad_mcp/tools/gui.py
@@ -75,9 +75,27 @@ def _xvfb_available() -> bool:
     return shutil.which("Xvfb") is not None
 
 
+def _get_openroad_exe() -> str | None:
+    """Resolve the OpenROAD executable path.
+
+    Checks (in order):
+    1. ``OPENROAD_EXE`` environment variable (used by OpenROAD-flow-scripts)
+    2. ``shutil.which("openroad")`` (standard PATH lookup)
+
+    Returns the absolute path string or *None* if not found.
+    """
+    env_exe = os.environ.get("OPENROAD_EXE")
+    if env_exe:
+        p = Path(env_exe)
+        if p.is_file() and os.access(str(p), os.X_OK):
+            return str(p.resolve())
+    found = shutil.which("openroad")
+    return found if found else None
+
+
 def _openroad_available() -> bool:
-    """Check whether openroad is on PATH."""
-    return shutil.which("openroad") is not None
+    """Check whether openroad can be found."""
+    return _get_openroad_exe() is not None
 
 
 def _import_available() -> bool:
@@ -327,13 +345,16 @@ class GuiScreenshotTool(BaseTool):
                 )
             )
 
-        if not _openroad_available():
+        openroad_exe = _get_openroad_exe()
+        if openroad_exe is None:
             return self._format_result(
                 GuiScreenshotResult(
                     error="OpenROADNotFound",
                     message=(
                         "openroad is not installed or not on PATH.  "
-                        "GUI screenshots require OpenROAD with GUI support.  "
+                        "Set the OPENROAD_EXE environment variable to the "
+                        "full path of the openroad binary, or add its "
+                        "directory to PATH.  "
                         "See https://openroad.readthedocs.io/ for installation."
                     ),
                 )
@@ -374,7 +395,7 @@ class GuiScreenshotTool(BaseTool):
 
         # --- Start OpenROAD on that display ---
         session_id = await self.manager.create_session(
-            command=["openroad", "-gui", "-no_init"],
+            command=[openroad_exe, "-gui", "-no_init"],
             env={"DISPLAY": f":{display_num}"},
         )
 

--- a/src/openroad_mcp/tools/gui.py
+++ b/src/openroad_mcp/tools/gui.py
@@ -60,7 +60,7 @@ _VALID_FORMATS = {"png", "jpeg", "webp"}
 _VALID_RETURN_MODES = {"base64", "path", "preview"}
 
 # Preview thumbnail max dimension (longest side)
-_PREVIEW_SIZE = 256
+_PREVIEW_SIZE: int = settings.GUI_PREVIEW_SIZE_PX
 
 
 # ---------------------------------------------------------------------------
@@ -110,7 +110,7 @@ def _find_free_display() -> int:
         if not lock.exists():
             return num
     # Fallback – use a high random number outside the configured range
-    return start + uuid.uuid4().int % 200
+    return start + uuid.uuid4().int % settings.GUI_DISPLAY_FALLBACK_RANGE
 
 
 async def _wait_for_display(display_num: int) -> bool:
@@ -134,7 +134,7 @@ async def _wait_for_display(display_num: int) -> bool:
                 stdout=asyncio.subprocess.DEVNULL,
                 stderr=asyncio.subprocess.DEVNULL,
             )
-            rc = await asyncio.wait_for(proc.wait(), timeout=3.0)
+            rc = await asyncio.wait_for(proc.wait(), timeout=settings.GUI_SUBPROCESS_TIMEOUT_S)
             if rc == 0:
                 logger.debug("Display :%d ready after %.1fs", display_num, elapsed)
                 return True
@@ -176,7 +176,7 @@ async def _wait_for_gui_ready(display_num: int) -> bool:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.DEVNULL,
             )
-            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=3.0)
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=settings.GUI_SUBPROCESS_TIMEOUT_S)
             if proc.returncode == 0:
                 output = stdout.decode("utf-8", errors="replace")
                 # Count lines that look like real child windows.
@@ -384,7 +384,7 @@ class GuiScreenshotTool(BaseTool):
             # 2.  Determine raw capture path (always PNG from import)
             # ----------------------------------------------------------
             tmp_dir = Path(tempfile.gettempdir())
-            raw_name = f"openroad_gui_raw_{uuid.uuid4().hex[:12]}.png"
+            raw_name = f"openroad_gui_raw_{uuid.uuid4().hex[: settings.GUI_TEMP_UUID_LENGTH]}.png"
             raw_path = tmp_dir / raw_name
             raw_path.unlink(missing_ok=True)
 
@@ -423,7 +423,7 @@ class GuiScreenshotTool(BaseTool):
                 )
 
             if proc.returncode != 0:
-                err_text = stderr.decode("utf-8", errors="replace")[:500]
+                err_text = stderr.decode("utf-8", errors="replace")[: settings.GUI_ERROR_TRUNCATE_CHARS]
                 return self._format_result(
                     GuiScreenshotResult(
                         session_id=session_id,
@@ -529,7 +529,7 @@ class GuiScreenshotTool(BaseTool):
                 # Create parent directories if they don't exist
                 final_path.parent.mkdir(parents=True, exist_ok=True)
             else:
-                final_name = f"openroad_gui_{uuid.uuid4().hex[:12]}{ext_map[fmt]}"
+                final_name = f"openroad_gui_{uuid.uuid4().hex[: settings.GUI_TEMP_UUID_LENGTH]}{ext_map[fmt]}"
                 final_path = tmp_dir / final_name
 
             final_path.write_bytes(processed_bytes)
@@ -714,7 +714,7 @@ class GuiScreenshotTool(BaseTool):
         )
 
         # Give Xvfb a moment to bind the display socket
-        await asyncio.sleep(1.0)
+        await asyncio.sleep(settings.GUI_XVFB_SETTLE_S)
 
         # Check that Xvfb is still running
         if xvfb_proc.returncode is not None:

--- a/tests/integration/test_gui.py
+++ b/tests/integration/test_gui.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import pytest
 
 from openroad_mcp.core.manager import OpenROADManager
-from openroad_mcp.tools.gui import GuiScreenshotTool
+from openroad_mcp.tools.gui import GuiScreenshotTool, _get_openroad_exe
 
 
 def _has_xvfb() -> bool:
@@ -21,7 +21,7 @@ def _has_xvfb() -> bool:
 
 
 def _has_openroad() -> bool:
-    return shutil.which("openroad") is not None
+    return _get_openroad_exe() is not None
 
 
 def _has_import() -> bool:

--- a/tests/integration/test_gui.py
+++ b/tests/integration/test_gui.py
@@ -1,0 +1,143 @@
+"""Integration tests for GUI screenshot tool under Xvfb."""
+
+import asyncio
+import base64
+import json
+import shutil
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from openroad_mcp.config.settings import settings
+from openroad_mcp.core.manager import OpenROADManager
+from openroad_mcp.tools.gui import GuiScreenshotTool
+
+
+def _has_xvfb() -> bool:
+    return shutil.which("xvfb-run") is not None
+
+
+def _has_openroad() -> bool:
+    return shutil.which("openroad") is not None
+
+
+skip_if_no_xvfb = pytest.mark.skipif(not _has_xvfb(), reason="xvfb-run not installed")
+skip_if_no_openroad = pytest.mark.skipif(not _has_openroad(), reason="openroad not installed")
+
+
+@pytest.mark.asyncio
+class TestGuiScreenshot:
+    """Tests for the gui_screenshot MCP tool."""
+
+    @pytest.fixture(autouse=True)
+    def allow_xvfb(self):
+        """Ensure xvfb-run is in the allowed commands list."""
+        original = settings.ALLOWED_COMMANDS[:]
+        if "xvfb-run" not in settings.ALLOWED_COMMANDS:
+            settings.ALLOWED_COMMANDS.append("xvfb-run")
+        yield
+        settings.ALLOWED_COMMANDS[:] = original
+
+    @pytest.fixture
+    async def manager(self):
+        """Provide a fresh OpenROADManager and clean up after."""
+        # Reset singleton so each test gets a clean manager
+        OpenROADManager._instance = None
+        mgr = OpenROADManager()
+        try:
+            yield mgr
+        finally:
+            await mgr.cleanup_all()
+            OpenROADManager._instance = None
+
+    @pytest.fixture
+    def tool(self, manager: OpenROADManager) -> GuiScreenshotTool:
+        return GuiScreenshotTool(manager)
+
+    # ------------------------------------------------------------------
+    # Unit-level: xvfb missing
+    # ------------------------------------------------------------------
+    async def test_returns_error_when_xvfb_missing(self, tool: GuiScreenshotTool):
+        """Tool should return a structured error when xvfb-run is absent."""
+        with patch("openroad_mcp.tools.gui._xvfb_available", return_value=False):
+            raw = await tool.execute()
+            result = json.loads(raw)
+
+        assert result["error"] == "XvfbNotFound"
+        assert "xvfb-run" in result["message"]
+
+    # ------------------------------------------------------------------
+    # Integration: full screenshot round-trip (Docker only)
+    # ------------------------------------------------------------------
+    @skip_if_no_xvfb
+    @skip_if_no_openroad
+    async def test_screenshot_creates_png(self, tool: GuiScreenshotTool):
+        """Launch headless GUI, capture screenshot, verify PNG base64."""
+        raw = await tool.execute(timeout_ms=15_000)
+        result = json.loads(raw)
+
+        # If the GUI failed to render it's an infra / timing issue, not a code bug
+        if result.get("error") in ("ScreenshotFailed", "SessionError"):
+            pytest.skip(f"GUI did not produce image (infra): {result.get('message', '')}")
+
+        assert result.get("error") is None, f"Unexpected error: {result}"
+        assert result["image_format"] == "png"
+        assert result["size_bytes"] > 0
+        assert result["session_id"] is not None
+
+        # Validate base64 payload
+        image_bytes = base64.b64decode(result["image_data"])
+        assert image_bytes[:4] == b"\x89PNG", "Response is not a valid PNG"
+
+        # File should exist on disk as well
+        assert Path(result["image_path"]).exists()
+
+    @skip_if_no_xvfb
+    @skip_if_no_openroad
+    async def test_screenshot_reuses_existing_session(self, tool: GuiScreenshotTool, manager: OpenROADManager):
+        """Providing an existing session_id should reuse that session."""
+        session_id = await manager.create_session(
+            command=[
+                "xvfb-run",
+                "-a",
+                "-s",
+                "-screen 0 1280x1024x24",
+                "openroad",
+                "-gui",
+                "-no_init",
+            ],
+        )
+        # Let the GUI boot
+        await asyncio.sleep(3.0)
+
+        raw = await tool.execute(session_id=session_id, timeout_ms=15_000)
+        result = json.loads(raw)
+
+        if result.get("error") == "ScreenshotFailed":
+            pytest.skip(f"GUI did not produce image (infra): {result.get('message', '')}")
+
+        assert result.get("error") is None, f"Unexpected error: {result}"
+        assert result["session_id"] == session_id
+
+    @skip_if_no_xvfb
+    @skip_if_no_openroad
+    async def test_screenshot_custom_output_path(self, tool: GuiScreenshotTool, tmp_path: Path):
+        """Custom output_path should place the PNG at the specified location."""
+        out = tmp_path / "my_screenshot.png"
+        raw = await tool.execute(output_path=str(out), timeout_ms=15_000)
+        result = json.loads(raw)
+
+        if result.get("error") == "ScreenshotFailed":
+            pytest.skip("GUI did not produce image (infra)")
+
+        assert result.get("error") is None
+        assert out.exists()
+        assert out.stat().st_size > 0
+
+    async def test_screenshot_invalid_session_id(self, tool: GuiScreenshotTool):
+        """Non-existent session_id should return SessionNotFound."""
+        raw = await tool.execute(session_id="nonexistent-id")
+        result = json.loads(raw)
+
+        assert result["error"] == "SessionNotFound"

--- a/tests/integration/test_gui.py
+++ b/tests/integration/test_gui.py
@@ -1,48 +1,45 @@
-"""Integration tests for GUI screenshot tool under Xvfb."""
+"""Integration tests for GUI screenshot tool under Xvfb.
 
-import asyncio
+These tests run inside a Docker container that has Xvfb, OpenROAD, and
+ImageMagick installed.  They are skipped when those prerequisites are
+not available (e.g. local development without OpenROAD).
+"""
+
 import base64
 import json
 import shutil
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 
-from openroad_mcp.config.settings import settings
 from openroad_mcp.core.manager import OpenROADManager
 from openroad_mcp.tools.gui import GuiScreenshotTool
 
 
 def _has_xvfb() -> bool:
-    return shutil.which("xvfb-run") is not None
+    return shutil.which("Xvfb") is not None
 
 
 def _has_openroad() -> bool:
     return shutil.which("openroad") is not None
 
 
-skip_if_no_xvfb = pytest.mark.skipif(not _has_xvfb(), reason="xvfb-run not installed")
+def _has_import() -> bool:
+    return shutil.which("import") is not None
+
+
+skip_if_no_xvfb = pytest.mark.skipif(not _has_xvfb(), reason="Xvfb not installed")
 skip_if_no_openroad = pytest.mark.skipif(not _has_openroad(), reason="openroad not installed")
+skip_if_no_import = pytest.mark.skipif(not _has_import(), reason="ImageMagick import not installed")
 
 
 @pytest.mark.asyncio
 class TestGuiScreenshot:
     """Tests for the gui_screenshot MCP tool."""
 
-    @pytest.fixture(autouse=True)
-    def allow_xvfb(self):
-        """Ensure xvfb-run is in the allowed commands list."""
-        original = settings.ALLOWED_COMMANDS[:]
-        if "xvfb-run" not in settings.ALLOWED_COMMANDS:
-            settings.ALLOWED_COMMANDS.append("xvfb-run")
-        yield
-        settings.ALLOWED_COMMANDS[:] = original
-
     @pytest.fixture
     async def manager(self):
         """Provide a fresh OpenROADManager and clean up after."""
-        # Reset singleton so each test gets a clean manager
         OpenROADManager._instance = None
         mgr = OpenROADManager()
         try:
@@ -56,25 +53,28 @@ class TestGuiScreenshot:
         return GuiScreenshotTool(manager)
 
     # ------------------------------------------------------------------
-    # Unit-level: xvfb missing
+    # Unit-level: Xvfb missing
     # ------------------------------------------------------------------
     async def test_returns_error_when_xvfb_missing(self, tool: GuiScreenshotTool):
-        """Tool should return a structured error when xvfb-run is absent."""
+        """Tool should return a structured error when Xvfb is absent."""
+        from unittest.mock import patch
+
         with patch("openroad_mcp.tools.gui._xvfb_available", return_value=False):
             raw = await tool.execute()
             result = json.loads(raw)
 
         assert result["error"] == "XvfbNotFound"
-        assert "xvfb-run" in result["message"]
+        assert "xvfb" in result["message"].lower()
 
     # ------------------------------------------------------------------
     # Integration: full screenshot round-trip (Docker only)
     # ------------------------------------------------------------------
     @skip_if_no_xvfb
     @skip_if_no_openroad
+    @skip_if_no_import
     async def test_screenshot_creates_png(self, tool: GuiScreenshotTool):
         """Launch headless GUI, capture screenshot, verify PNG base64."""
-        raw = await tool.execute(timeout_ms=15_000)
+        raw = await tool.execute(timeout_ms=25_000)
         result = json.loads(raw)
 
         # If the GUI failed to render it's an infra / timing issue, not a code bug
@@ -93,47 +93,49 @@ class TestGuiScreenshot:
         # File should exist on disk as well
         assert Path(result["image_path"]).exists()
 
-    @skip_if_no_xvfb
-    @skip_if_no_openroad
-    async def test_screenshot_reuses_existing_session(self, tool: GuiScreenshotTool, manager: OpenROADManager):
-        """Providing an existing session_id should reuse that session."""
-        session_id = await manager.create_session(
-            command=[
-                "xvfb-run",
-                "-a",
-                "-s",
-                "-screen 0 1280x1024x24",
-                "openroad",
-                "-gui",
-                "-no_init",
-            ],
-        )
-        # Let the GUI boot
-        await asyncio.sleep(3.0)
-
-        raw = await tool.execute(session_id=session_id, timeout_ms=15_000)
-        result = json.loads(raw)
-
-        if result.get("error") == "ScreenshotFailed":
-            pytest.skip(f"GUI did not produce image (infra): {result.get('message', '')}")
-
-        assert result.get("error") is None, f"Unexpected error: {result}"
-        assert result["session_id"] == session_id
+        # Cleanup Xvfb
+        tool.cleanup_display(result["session_id"])
 
     @skip_if_no_xvfb
     @skip_if_no_openroad
+    @skip_if_no_import
+    async def test_screenshot_reuses_existing_session(self, tool: GuiScreenshotTool):
+        """Taking a second screenshot should reuse the same session."""
+        raw1 = await tool.execute(timeout_ms=25_000)
+        r1 = json.loads(raw1)
+
+        if r1.get("error"):
+            pytest.skip(f"First screenshot failed (infra): {r1.get('message', '')}")
+
+        # Second screenshot on the same session
+        raw2 = await tool.execute(session_id=r1["session_id"], timeout_ms=15_000)
+        r2 = json.loads(raw2)
+
+        if r2.get("error"):
+            pytest.skip(f"Second screenshot failed (infra): {r2.get('message', '')}")
+
+        assert r2["session_id"] == r1["session_id"]
+        assert r2["size_bytes"] > 0
+
+        tool.cleanup_display(r1["session_id"])
+
+    @skip_if_no_xvfb
+    @skip_if_no_openroad
+    @skip_if_no_import
     async def test_screenshot_custom_output_path(self, tool: GuiScreenshotTool, tmp_path: Path):
         """Custom output_path should place the PNG at the specified location."""
         out = tmp_path / "my_screenshot.png"
-        raw = await tool.execute(output_path=str(out), timeout_ms=15_000)
+        raw = await tool.execute(output_path=str(out), timeout_ms=30_000)
         result = json.loads(raw)
 
-        if result.get("error") == "ScreenshotFailed":
+        if result.get("error") in ("ScreenshotFailed", "SessionError"):
             pytest.skip("GUI did not produce image (infra)")
 
         assert result.get("error") is None
         assert out.exists()
         assert out.stat().st_size > 0
+
+        tool.cleanup_display(result["session_id"])
 
     async def test_screenshot_invalid_session_id(self, tool: GuiScreenshotTool):
         """Non-existent session_id should return SessionNotFound."""

--- a/tests/integration/test_gui.py
+++ b/tests/integration/test_gui.py
@@ -72,8 +72,8 @@ class TestGuiScreenshot:
     @skip_if_no_xvfb
     @skip_if_no_openroad
     @skip_if_no_import
-    async def test_screenshot_creates_png(self, tool: GuiScreenshotTool):
-        """Launch headless GUI, capture screenshot, verify PNG base64."""
+    async def test_screenshot_default_jpeg(self, tool: GuiScreenshotTool):
+        """Launch headless GUI, capture screenshot, verify JPEG base64 (default format)."""
         raw = await tool.execute(timeout_ms=25_000)
         result = json.loads(raw)
 
@@ -82,13 +82,15 @@ class TestGuiScreenshot:
             pytest.skip(f"GUI did not produce image (infra): {result.get('message', '')}")
 
         assert result.get("error") is None, f"Unexpected error: {result}"
-        assert result["image_format"] == "png"
+        assert result["image_format"] == "jpeg"  # default format
         assert result["size_bytes"] > 0
         assert result["session_id"] is not None
+        assert result["return_mode"] == "base64"
+        assert result["compression_applied"] is True
 
-        # Validate base64 payload
+        # Validate base64 payload (JPEG signature: FF D8)
         image_bytes = base64.b64decode(result["image_data"])
-        assert image_bytes[:4] == b"\x89PNG", "Response is not a valid PNG"
+        assert image_bytes[:2] == b"\xff\xd8", "Response is not a valid JPEG"
 
         # File should exist on disk as well
         assert Path(result["image_path"]).exists()

--- a/tests/tools/test_gui_tool.py
+++ b/tests/tools/test_gui_tool.py
@@ -7,12 +7,14 @@ tests/integration/test_gui.py.
 
 import asyncio
 import base64
+import io
 import json
 import tempfile
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from PIL import Image as PILImage
 
 from openroad_mcp.config.settings import settings
 from openroad_mcp.tools.gui import (
@@ -61,6 +63,49 @@ def _make_xvfb_proc(*, pid: int = 12345, returncode: int | None = None):
     return proc
 
 
+def _make_import_side_effect(
+    *,
+    returncode: int = 0,
+    stderr: bytes = b"",
+    png_data: bytes | None = None,
+):
+    """Return an async callable for ``side_effect`` of
+    ``asyncio.create_subprocess_exec`` that mimics ImageMagick ``import``.
+
+    Unlike ``_make_import_proc`` this dynamically captures the output-path
+    from the call arguments (``import -window root <path>``) so the test
+    does not need to know the internal raw-path name.
+
+    When *png_data* is given it is written instead of ``_MINIMAL_PNG``.
+    """
+    data = png_data if png_data is not None else _MINIMAL_PNG
+
+    async def _factory(*args, **kwargs):
+        proc = AsyncMock()
+        proc.returncode = returncode
+        proc.kill = MagicMock()
+        # ``import -window root <path>``  →  args[3] is the path
+        img_path = args[3] if len(args) > 3 else None
+
+        async def _communicate():
+            if returncode == 0 and img_path is not None:
+                Path(img_path).write_bytes(data)
+            return b"", stderr
+
+        proc.communicate = _communicate
+        return proc
+
+    return _factory
+
+
+def _create_test_png(width: int = 100, height: int = 80) -> bytes:
+    """Create a solid-colour PNG of the given dimensions using Pillow."""
+    img = PILImage.new("RGBA", (width, height), (255, 0, 0, 255))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
 @pytest.mark.asyncio
 class TestGuiScreenshotTool:
     """Test suite for GuiScreenshotTool."""
@@ -82,43 +127,47 @@ class TestGuiScreenshotTool:
     # Positive: successful screenshot (happy path, existing session)
     # ------------------------------------------------------------------
     async def test_successful_screenshot(self, tool, tmp_path):
-        """Full happy path: existing session → import -window root → PNG."""
-        out_file = tmp_path / "screenshot.png"
+        """Full happy path: existing session → import → JPEG (default)."""
+        out_file = tmp_path / "screenshot.jpg"
         self._register_display(tool, "gui-sess-1")
 
-        mock_proc = _make_import_proc(out_file)
-
-        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+        with patch("asyncio.create_subprocess_exec", side_effect=_make_import_side_effect()):
             raw = await tool.execute(session_id="gui-sess-1", output_path=str(out_file))
 
         result = json.loads(raw)
         assert result["error"] is None
         assert result["session_id"] == "gui-sess-1"
-        assert result["image_format"] == "png"
-        assert result["size_bytes"] == len(_MINIMAL_PNG)
+        assert result["image_format"] == "jpeg"  # default
+        assert result["size_bytes"] > 0
+        assert result["original_size_bytes"] > 0
+        assert result["compression_applied"] is True
+        assert result["return_mode"] == "base64"
+        assert result["width"] == 1
+        assert result["height"] == 1
         assert result["message"] == "Screenshot captured successfully."
-        assert base64.b64decode(result["image_data"]) == _MINIMAL_PNG
+        # Verify base64 data decodes to valid image bytes
+        img_bytes = base64.b64decode(result["image_data"])
+        assert len(img_bytes) > 0
 
     # ------------------------------------------------------------------
     # Positive: auto-session creation (Xvfb + OpenROAD)
     # ------------------------------------------------------------------
     async def test_successful_screenshot_auto_session(self, tool, mock_manager, tmp_path):
         """When no session_id is given, Xvfb + OpenROAD are started."""
-        out_file = tmp_path / "auto.png"
+        out_file = tmp_path / "auto.jpg"
         mock_manager.create_session.return_value = "auto-sess"
 
         xvfb_proc = _make_xvfb_proc()
+        import_factory = _make_import_side_effect()
 
-        # First call → Xvfb, second call → import
+        # First call → Xvfb, subsequent calls → import
         calls = [0]
 
         async def _create_sub(*args, **kwargs):
             calls[0] += 1
             if calls[0] == 1:
-                # Xvfb
                 return xvfb_proc
-            # import
-            return _make_import_proc(out_file)
+            return await import_factory(*args, **kwargs)
 
         with (
             patch("openroad_mcp.tools.gui._xvfb_available", return_value=True),
@@ -145,23 +194,23 @@ class TestGuiScreenshotTool:
     # ------------------------------------------------------------------
     async def test_default_resolution_and_timeout(self, tool, tmp_path):
         """Defaults for resolution and timeout are applied."""
-        out_file = tmp_path / "defaults.png"
+        out_file = tmp_path / "defaults.jpg"
         self._register_display(tool, "s1")
 
-        mock_proc = _make_import_proc(out_file)
-
-        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+        with patch("asyncio.create_subprocess_exec", side_effect=_make_import_side_effect()):
             raw = await tool.execute(session_id="s1", output_path=str(out_file))
 
         result = json.loads(raw)
+        assert result["error"] is None
         assert result["resolution"] == settings.GUI_DISPLAY_RESOLUTION
 
     async def test_custom_resolution(self, tool, mock_manager, tmp_path):
         """Custom resolution is threaded through to result and Xvfb start."""
-        out_file = tmp_path / "res.png"
+        out_file = tmp_path / "res.jpg"
         mock_manager.create_session.return_value = "res-sess"
 
         xvfb_proc = _make_xvfb_proc()
+        import_factory = _make_import_side_effect()
         calls = [0]
 
         async def _create_sub(*args, **kwargs):
@@ -170,7 +219,7 @@ class TestGuiScreenshotTool:
                 # Xvfb – verify resolution is passed
                 assert "1920x1080x24" in args
                 return xvfb_proc
-            return _make_import_proc(out_file)
+            return await import_factory(*args, **kwargs)
 
         with (
             patch("openroad_mcp.tools.gui._xvfb_available", return_value=True),
@@ -183,6 +232,7 @@ class TestGuiScreenshotTool:
             raw = await tool.execute(resolution="1920x1080x24", output_path=str(out_file))
 
         result = json.loads(raw)
+        assert result["error"] is None
         assert result["resolution"] == "1920x1080x24"
 
     async def test_custom_timeout(self, tool, tmp_path):
@@ -209,25 +259,16 @@ class TestGuiScreenshotTool:
         """When output_path is omitted a temp file under /tmp is used."""
         self._register_display(tool, "s1")
 
-        captured_path: list[str] = []
-
-        async def _capture(*args, **kwargs):
-            # The 4th positional arg to import is the image path
-            path_str = args[3]
-            captured_path.append(path_str)
-            return _make_import_proc(path_str)
-
-        with patch("asyncio.create_subprocess_exec", side_effect=_capture):
+        with patch("asyncio.create_subprocess_exec", side_effect=_make_import_side_effect()):
             raw = await tool.execute(session_id="s1")
 
         result = json.loads(raw)
         assert result["error"] is None
         assert result["image_path"].startswith(tempfile.gettempdir())
-        assert result["image_path"].endswith(".png")
+        assert result["image_path"].endswith(".jpg")  # default JPEG
 
         # Cleanup
-        for p in captured_path:
-            Path(p).unlink(missing_ok=True)
+        Path(result["image_path"]).unlink(missing_ok=True)
 
     # ------------------------------------------------------------------
     # Negative: pre-flight checks
@@ -322,27 +363,20 @@ class TestGuiScreenshotTool:
     # Negative: file too large
     # ------------------------------------------------------------------
     async def test_file_too_large_error(self, tool, tmp_path):
-        """Returns FileTooLarge when screenshot exceeds configured max size."""
-        out_file = tmp_path / "huge.png"
+        """Returns FileTooLarge when processed screenshot exceeds max size."""
+        out_file = tmp_path / "huge.jpg"
         self._register_display(tool, "s1")
-        max_mb = settings.GUI_MAX_SCREENSHOT_SIZE_MB
-        huge_size = (max_mb + 1) * 1024 * 1024
 
-        mock_proc = AsyncMock()
-        mock_proc.returncode = 0
-
-        async def _big():
-            out_file.write_bytes(b"\x00" * huge_size)
-            return b"", b""
-
-        mock_proc.communicate = _big
-
-        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+        # Set max to 0 so any image exceeds the limit
+        with (
+            patch("asyncio.create_subprocess_exec", side_effect=_make_import_side_effect()),
+            patch.object(settings, "GUI_MAX_SCREENSHOT_SIZE_MB", 0),
+        ):
             raw = await tool.execute(session_id="s1", output_path=str(out_file))
 
         result = json.loads(raw)
         assert result["error"] == "FileTooLarge"
-        assert str(max_mb) in result["message"]
+        assert "exceeds" in result["message"].lower()
 
     # ------------------------------------------------------------------
     # Negative: session display not registered
@@ -394,32 +428,30 @@ class TestGuiScreenshotTool:
     # ------------------------------------------------------------------
     # Edge: stale file is cleaned before capture
     # ------------------------------------------------------------------
-    async def test_stale_file_removed_before_capture(self, tool, tmp_path):
-        """A stale file at the output path is removed before import."""
-        out_file = tmp_path / "stale.png"
+    async def test_stale_file_overwritten(self, tool, tmp_path):
+        """A stale file at the output path is overwritten with the new image."""
+        out_file = tmp_path / "stale.jpg"
         out_file.write_bytes(b"old data")
         self._register_display(tool, "s1")
 
-        mock_proc = _make_import_proc(out_file)
-
-        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+        with patch("asyncio.create_subprocess_exec", side_effect=_make_import_side_effect()):
             raw = await tool.execute(session_id="s1", output_path=str(out_file))
 
         result = json.loads(raw)
         assert result["error"] is None
-        assert base64.b64decode(result["image_data"]) == _MINIMAL_PNG
+        # File should contain new image, not old data
+        assert out_file.read_bytes() != b"old data"
+        assert result["size_bytes"] > 0
 
     # ------------------------------------------------------------------
     # Result structure: all expected fields present
     # ------------------------------------------------------------------
     async def test_result_contains_all_fields(self, tool, tmp_path):
         """Successful result includes every GuiScreenshotResult field."""
-        out_file = tmp_path / "fields.png"
+        out_file = tmp_path / "fields.jpg"
         self._register_display(tool, "s1")
 
-        mock_proc = _make_import_proc(out_file)
-
-        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+        with patch("asyncio.create_subprocess_exec", side_effect=_make_import_side_effect()):
             raw = await tool.execute(session_id="s1", output_path=str(out_file))
 
         result = json.loads(raw)
@@ -429,12 +461,427 @@ class TestGuiScreenshotTool:
             "image_path",
             "image_format",
             "size_bytes",
+            "original_size_bytes",
             "resolution",
             "timestamp",
             "message",
             "error",
+            "return_mode",
+            "compression_applied",
+            "compression_ratio",
+            "width",
+            "height",
         }
         assert expected_keys.issubset(result.keys()), f"Missing: {expected_keys - result.keys()}"
+
+    # ------------------------------------------------------------------
+    # Image format tests
+    # ------------------------------------------------------------------
+    async def test_explicit_png_format(self, tool, tmp_path):
+        """Explicit image_format='png' produces a PNG."""
+        out_file = tmp_path / "shot.png"
+        self._register_display(tool, "s1")
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_make_import_side_effect()):
+            raw = await tool.execute(session_id="s1", output_path=str(out_file), image_format="png")
+
+        result = json.loads(raw)
+        assert result["error"] is None
+        assert result["image_format"] == "png"
+        # PNG signature: starts with \x89PNG
+        img_bytes = base64.b64decode(result["image_data"])
+        assert img_bytes[:4] == b"\x89PNG"
+
+    async def test_webp_format(self, tool, tmp_path):
+        """image_format='webp' produces a WebP file."""
+        out_file = tmp_path / "shot.webp"
+        self._register_display(tool, "s1")
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_make_import_side_effect()):
+            raw = await tool.execute(session_id="s1", output_path=str(out_file), image_format="webp")
+
+        result = json.loads(raw)
+        assert result["error"] is None
+        assert result["image_format"] == "webp"
+        # WebP signature: starts with RIFF....WEBP
+        img_bytes = base64.b64decode(result["image_data"])
+        assert img_bytes[:4] == b"RIFF"
+        assert img_bytes[8:12] == b"WEBP"
+
+    async def test_jpeg_default_format(self, tool, tmp_path):
+        """Default format is JPEG; RGBA PNG gets converted to RGB."""
+        out_file = tmp_path / "shot.jpg"
+        self._register_display(tool, "s1")
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_make_import_side_effect()):
+            raw = await tool.execute(session_id="s1", output_path=str(out_file))
+
+        result = json.loads(raw)
+        assert result["error"] is None
+        assert result["image_format"] == "jpeg"
+        # JPEG signature: starts with FF D8 FF
+        img_bytes = base64.b64decode(result["image_data"])
+        assert img_bytes[:2] == b"\xff\xd8"
+
+    # ------------------------------------------------------------------
+    # Quality tests
+    # ------------------------------------------------------------------
+    async def test_jpeg_quality_low(self, tool, tmp_path):
+        """Low quality JPEG produces a smaller file than high quality."""
+        self._register_display(tool, "s1")
+
+        # Use a larger PNG so quality difference is measurable
+        big_png = _create_test_png(100, 80)
+
+        with patch(
+            "asyncio.create_subprocess_exec",
+            side_effect=_make_import_side_effect(png_data=big_png),
+        ):
+            raw_low = await tool.execute(
+                session_id="s1",
+                output_path=str(tmp_path / "low.jpg"),
+                quality=10,
+            )
+
+        with patch(
+            "asyncio.create_subprocess_exec",
+            side_effect=_make_import_side_effect(png_data=big_png),
+        ):
+            raw_high = await tool.execute(
+                session_id="s1",
+                output_path=str(tmp_path / "high.jpg"),
+                quality=95,
+            )
+
+        low = json.loads(raw_low)
+        high = json.loads(raw_high)
+        assert low["error"] is None
+        assert high["error"] is None
+        assert low["size_bytes"] < high["size_bytes"]
+
+    # ------------------------------------------------------------------
+    # Scale tests
+    # ------------------------------------------------------------------
+    async def test_scale_downscale(self, tool, tmp_path):
+        """scale=0.5 halves the image dimensions."""
+        out_file = tmp_path / "scaled.jpg"
+        self._register_display(tool, "s1")
+
+        big_png = _create_test_png(100, 80)
+
+        with patch(
+            "asyncio.create_subprocess_exec",
+            side_effect=_make_import_side_effect(png_data=big_png),
+        ):
+            raw = await tool.execute(
+                session_id="s1",
+                output_path=str(out_file),
+                scale=0.5,
+            )
+
+        result = json.loads(raw)
+        assert result["error"] is None
+        assert result["width"] == 50
+        assert result["height"] == 40
+        assert result["compression_applied"] is True
+
+    async def test_scale_one_no_resize(self, tool, tmp_path):
+        """scale=1.0 (default) preserves original dimensions."""
+        out_file = tmp_path / "noscale.jpg"
+        self._register_display(tool, "s1")
+
+        big_png = _create_test_png(100, 80)
+
+        with patch(
+            "asyncio.create_subprocess_exec",
+            side_effect=_make_import_side_effect(png_data=big_png),
+        ):
+            raw = await tool.execute(
+                session_id="s1",
+                output_path=str(out_file),
+                scale=1.0,
+            )
+
+        result = json.loads(raw)
+        assert result["error"] is None
+        assert result["width"] == 100
+        assert result["height"] == 80
+
+    # ------------------------------------------------------------------
+    # Crop tests
+    # ------------------------------------------------------------------
+    async def test_crop_region(self, tool, tmp_path):
+        """Cropping extracts a subregion of the image."""
+        out_file = tmp_path / "cropped.jpg"
+        self._register_display(tool, "s1")
+
+        big_png = _create_test_png(100, 80)
+
+        with patch(
+            "asyncio.create_subprocess_exec",
+            side_effect=_make_import_side_effect(png_data=big_png),
+        ):
+            raw = await tool.execute(
+                session_id="s1",
+                output_path=str(out_file),
+                crop="10 10 60 50",
+            )
+
+        result = json.loads(raw)
+        assert result["error"] is None
+        assert result["width"] == 50  # 60 - 10
+        assert result["height"] == 40  # 50 - 10
+        assert result["compression_applied"] is True
+
+    async def test_crop_then_scale(self, tool, tmp_path):
+        """Crop is applied before scale: crop first, then resize."""
+        out_file = tmp_path / "crop_scale.jpg"
+        self._register_display(tool, "s1")
+
+        big_png = _create_test_png(100, 80)
+
+        with patch(
+            "asyncio.create_subprocess_exec",
+            side_effect=_make_import_side_effect(png_data=big_png),
+        ):
+            raw = await tool.execute(
+                session_id="s1",
+                output_path=str(out_file),
+                crop="0 0 100 80",
+                scale=0.5,
+            )
+
+        result = json.loads(raw)
+        assert result["error"] is None
+        assert result["width"] == 50
+        assert result["height"] == 40
+
+    async def test_crop_invalid_format(self, tool, tmp_path):
+        """Invalid crop string returns InvalidParameter error."""
+        out_file = tmp_path / "bad_crop.jpg"
+        self._register_display(tool, "s1")
+
+        big_png = _create_test_png(100, 80)
+
+        with patch(
+            "asyncio.create_subprocess_exec",
+            side_effect=_make_import_side_effect(png_data=big_png),
+        ):
+            raw = await tool.execute(
+                session_id="s1",
+                output_path=str(out_file),
+                crop="not numbers",
+            )
+
+        result = json.loads(raw)
+        assert result["error"] == "InvalidParameter"
+        assert "crop" in result["message"].lower()
+
+    async def test_crop_wrong_count(self, tool, tmp_path):
+        """Crop with wrong number of coordinates returns error."""
+        out_file = tmp_path / "bad_crop2.jpg"
+        self._register_display(tool, "s1")
+
+        big_png = _create_test_png(100, 80)
+
+        with patch(
+            "asyncio.create_subprocess_exec",
+            side_effect=_make_import_side_effect(png_data=big_png),
+        ):
+            raw = await tool.execute(
+                session_id="s1",
+                output_path=str(out_file),
+                crop="10 20 30",
+            )
+
+        result = json.loads(raw)
+        assert result["error"] == "InvalidParameter"
+        assert "4" in result["message"]
+
+    # ------------------------------------------------------------------
+    # Return mode tests
+    # ------------------------------------------------------------------
+    async def test_return_mode_path(self, tool, tmp_path):
+        """return_mode='path' omits image_data for token savings."""
+        out_file = tmp_path / "path_only.jpg"
+        self._register_display(tool, "s1")
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_make_import_side_effect()):
+            raw = await tool.execute(
+                session_id="s1",
+                output_path=str(out_file),
+                return_mode="path",
+            )
+
+        result = json.loads(raw)
+        assert result["error"] is None
+        assert result["return_mode"] == "path"
+        assert result["image_data"] is None
+        assert result["image_path"] == str(out_file)
+        assert result["size_bytes"] > 0
+        assert "saved to" in result["message"].lower()
+
+    async def test_return_mode_preview(self, tool, tmp_path):
+        """return_mode='preview' returns a small thumbnail and the full path."""
+        out_file = tmp_path / "preview.jpg"
+        self._register_display(tool, "s1")
+
+        big_png = _create_test_png(100, 80)
+
+        with patch(
+            "asyncio.create_subprocess_exec",
+            side_effect=_make_import_side_effect(png_data=big_png),
+        ):
+            raw = await tool.execute(
+                session_id="s1",
+                output_path=str(out_file),
+                return_mode="preview",
+            )
+
+        result = json.loads(raw)
+        assert result["error"] is None
+        assert result["return_mode"] == "preview"
+        assert result["image_data"] is not None
+        assert result["image_path"] == str(out_file)
+        assert "preview" in result["message"].lower() or "thumbnail" in result["message"].lower()
+
+        # Preview image should be smaller than or equal to 256px on longest side
+        preview_bytes = base64.b64decode(result["image_data"])
+        preview_img = PILImage.open(io.BytesIO(preview_bytes))
+        assert max(preview_img.size) <= 256
+        preview_img.close()
+
+    async def test_return_mode_base64_default(self, tool, tmp_path):
+        """Default return_mode is 'base64' with full image data."""
+        out_file = tmp_path / "base64.jpg"
+        self._register_display(tool, "s1")
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_make_import_side_effect()):
+            raw = await tool.execute(
+                session_id="s1",
+                output_path=str(out_file),
+            )
+
+        result = json.loads(raw)
+        assert result["error"] is None
+        assert result["return_mode"] == "base64"
+        assert result["image_data"] is not None
+        assert result["image_path"] == str(out_file)
+
+    # ------------------------------------------------------------------
+    # Parameter validation tests
+    # ------------------------------------------------------------------
+    async def test_invalid_format_error(self, tool):
+        """Unsupported image format returns InvalidParameter."""
+        self._register_display(tool, "s1")
+
+        raw = await tool.execute(session_id="s1", image_format="bmp")
+
+        result = json.loads(raw)
+        assert result["error"] == "InvalidParameter"
+        assert "bmp" in result["message"]
+        assert "jpeg" in result["message"]
+
+    async def test_invalid_return_mode_error(self, tool):
+        """Unsupported return_mode returns InvalidParameter."""
+        self._register_display(tool, "s1")
+
+        raw = await tool.execute(session_id="s1", return_mode="inline")
+
+        result = json.loads(raw)
+        assert result["error"] == "InvalidParameter"
+        assert "inline" in result["message"]
+        assert "base64" in result["message"]
+
+    async def test_invalid_scale_zero(self, tool):
+        """scale=0 returns InvalidParameter."""
+        self._register_display(tool, "s1")
+
+        raw = await tool.execute(session_id="s1", scale=0.0)
+
+        result = json.loads(raw)
+        assert result["error"] == "InvalidParameter"
+        assert "scale" in result["message"].lower()
+
+    async def test_invalid_scale_negative(self, tool):
+        """Negative scale returns InvalidParameter."""
+        self._register_display(tool, "s1")
+
+        raw = await tool.execute(session_id="s1", scale=-0.5)
+
+        result = json.loads(raw)
+        assert result["error"] == "InvalidParameter"
+        assert "scale" in result["message"].lower()
+
+    async def test_invalid_scale_over_one(self, tool):
+        """scale > 1.0 returns InvalidParameter."""
+        self._register_display(tool, "s1")
+
+        raw = await tool.execute(session_id="s1", scale=1.5)
+
+        result = json.loads(raw)
+        assert result["error"] == "InvalidParameter"
+        assert "scale" in result["message"].lower()
+
+    async def test_invalid_quality_zero(self, tool):
+        """quality=0 returns InvalidParameter."""
+        self._register_display(tool, "s1")
+
+        raw = await tool.execute(session_id="s1", quality=0)
+
+        result = json.loads(raw)
+        assert result["error"] == "InvalidParameter"
+        assert "quality" in result["message"].lower()
+
+    async def test_invalid_quality_over_100(self, tool):
+        """quality=101 returns InvalidParameter."""
+        self._register_display(tool, "s1")
+
+        raw = await tool.execute(session_id="s1", quality=101)
+
+        result = json.loads(raw)
+        assert result["error"] == "InvalidParameter"
+        assert "quality" in result["message"].lower()
+
+    # ------------------------------------------------------------------
+    # Compression ratio field
+    # ------------------------------------------------------------------
+    async def test_compression_ratio_jpeg(self, tool, tmp_path):
+        """JPEG compression reports a non-None compression_ratio."""
+        out_file = tmp_path / "ratio.jpg"
+        self._register_display(tool, "s1")
+
+        big_png = _create_test_png(100, 80)
+
+        with patch(
+            "asyncio.create_subprocess_exec",
+            side_effect=_make_import_side_effect(png_data=big_png),
+        ):
+            raw = await tool.execute(session_id="s1", output_path=str(out_file))
+
+        result = json.loads(raw)
+        assert result["error"] is None
+        assert result["compression_applied"] is True
+        assert result["compression_ratio"] is not None
+        assert 0 < result["compression_ratio"]  # ratio > 0
+        assert result["original_size_bytes"] > 0
+
+    async def test_no_compression_png(self, tool, tmp_path):
+        """PNG at scale=1.0 with no crop reports compression_applied=False."""
+        out_file = tmp_path / "plain.png"
+        self._register_display(tool, "s1")
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_make_import_side_effect()):
+            raw = await tool.execute(
+                session_id="s1",
+                output_path=str(out_file),
+                image_format="png",
+            )
+
+        result = json.loads(raw)
+        assert result["error"] is None
+        assert result["compression_applied"] is False
+        assert result["compression_ratio"] is None
 
     # ------------------------------------------------------------------
     # Xvfb start failure

--- a/tests/tools/test_gui_tool.py
+++ b/tests/tools/test_gui_tool.py
@@ -754,7 +754,17 @@ class TestGuiScreenshotTool:
         preview_bytes = base64.b64decode(result["image_data"])
         preview_img = PILImage.open(io.BytesIO(preview_bytes))
         assert max(preview_img.size) <= 256
+        # Result metadata must reflect the thumbnail, not the full image
+        assert result["width"] == preview_img.size[0]
+        assert result["height"] == preview_img.size[1]
+        assert result["size_bytes"] == len(preview_bytes)
         preview_img.close()
+
+        # File on disk must also be the thumbnail, not the full-size image
+        disk_img = PILImage.open(out_file)
+        assert max(disk_img.size) <= 256
+        assert disk_img.size == (result["width"], result["height"])
+        disk_img.close()
 
     async def test_return_mode_base64_default(self, tool, tmp_path):
         """Default return_mode is 'base64' with full image data."""

--- a/tests/tools/test_gui_tool.py
+++ b/tests/tools/test_gui_tool.py
@@ -1053,6 +1053,92 @@ class TestGuiScreenshotTool:
         assert result["image_path"] == str(out_file)
         assert out_file.exists()
 
+    # ------------------------------------------------------------------
+    # Whitespace stripping (MCP Inspector may pad string values)
+    # ------------------------------------------------------------------
+    async def test_whitespace_padded_image_format(self, tool, tmp_path):
+        """Whitespace around image_format should be stripped."""
+        out_file = tmp_path / "shot.png"
+        self._register_display(tool, "s1")
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_make_import_side_effect()):
+            raw = await tool.execute(session_id="s1", output_path=str(out_file), image_format="  png  ")
+
+        result = json.loads(raw)
+        assert result["error"] is None
+        assert result["image_format"] == "png"
+
+    async def test_whitespace_padded_return_mode(self, tool, tmp_path):
+        """Whitespace around return_mode should be stripped."""
+        out_file = tmp_path / "shot.jpg"
+        self._register_display(tool, "s1")
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_make_import_side_effect()):
+            raw = await tool.execute(session_id="s1", output_path=str(out_file), return_mode="  path  ")
+
+        result = json.loads(raw)
+        assert result["error"] is None
+        assert result["return_mode"] == "path"
+        assert result["image_data"] is None
+
+    # ------------------------------------------------------------------
+    # Crop: comma separators and numeric input
+    # ------------------------------------------------------------------
+    async def test_crop_with_commas(self, tool, tmp_path):
+        """Comma-separated crop values should be accepted."""
+        out_file = tmp_path / "cropped.jpg"
+        self._register_display(tool, "s1")
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_make_import_side_effect()):
+            raw = await tool.execute(session_id="s1", output_path=str(out_file), crop="10,10,50,50")
+
+        result = json.loads(raw)
+        assert result["error"] is None
+
+    async def test_crop_with_mixed_separators(self, tool, tmp_path):
+        """Crop values with mixed commas and spaces should be accepted."""
+        out_file = tmp_path / "cropped.jpg"
+        self._register_display(tool, "s1")
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_make_import_side_effect()):
+            raw = await tool.execute(session_id="s1", output_path=str(out_file), crop="10, 10, 50, 50")
+
+        result = json.loads(raw)
+        assert result["error"] is None
+
+    # ------------------------------------------------------------------
+    # Extension validation: .jpeg recognised for jpeg format
+    # ------------------------------------------------------------------
+    async def test_jpeg_extension_preserved(self, tool, tmp_path):
+        """.jpeg extension should be accepted for jpeg format."""
+        out_file = tmp_path / "shot.jpeg"
+        self._register_display(tool, "s1")
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_make_import_side_effect()):
+            raw = await tool.execute(session_id="s1", output_path=str(out_file), image_format="jpeg")
+
+        result = json.loads(raw)
+        assert result["error"] is None
+        # .jpeg should be preserved, not changed to .jpg
+        assert result["image_path"] == str(out_file)
+
+    # ------------------------------------------------------------------
+    # return_mode=path: no image data, only file path
+    # ------------------------------------------------------------------
+    async def test_return_mode_path_omits_image_data(self, tool, tmp_path):
+        """return_mode='path' should omit image_data."""
+        out_file = tmp_path / "shot.jpg"
+        self._register_display(tool, "s1")
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_make_import_side_effect()):
+            raw = await tool.execute(session_id="s1", output_path=str(out_file), return_mode="path")
+
+        result = json.loads(raw)
+        assert result["error"] is None
+        assert result["return_mode"] == "path"
+        assert result["image_data"] is None
+        assert result["image_path"] is not None
+
 
 # ------------------------------------------------------------------
 # Standalone helper tests

--- a/tests/tools/test_gui_tool.py
+++ b/tests/tools/test_gui_tool.py
@@ -16,9 +16,9 @@ import pytest
 
 from openroad_mcp.config.settings import settings
 from openroad_mcp.tools.gui import (
-    MAX_SCREENSHOT_SIZE_MB,
     GuiScreenshotTool,
     _find_free_display,
+    _wait_for_display,
 )
 
 # Minimal valid PNG (1×1 pixel, RGBA)
@@ -126,6 +126,7 @@ class TestGuiScreenshotTool:
             patch("openroad_mcp.tools.gui._import_available", return_value=True),
             patch("asyncio.create_subprocess_exec", side_effect=_create_sub),
             patch("asyncio.sleep", new_callable=AsyncMock),
+            patch("openroad_mcp.tools.gui._wait_for_display", new_callable=AsyncMock, return_value=True),
         ):
             raw = await tool.execute(output_path=str(out_file))
 
@@ -177,6 +178,7 @@ class TestGuiScreenshotTool:
             patch("openroad_mcp.tools.gui._import_available", return_value=True),
             patch("asyncio.create_subprocess_exec", side_effect=_create_sub),
             patch("asyncio.sleep", new_callable=AsyncMock),
+            patch("openroad_mcp.tools.gui._wait_for_display", new_callable=AsyncMock, return_value=True),
         ):
             raw = await tool.execute(resolution="1920x1080x24", output_path=str(out_file))
 
@@ -320,10 +322,11 @@ class TestGuiScreenshotTool:
     # Negative: file too large
     # ------------------------------------------------------------------
     async def test_file_too_large_error(self, tool, tmp_path):
-        """Returns FileTooLarge when screenshot exceeds MAX_SCREENSHOT_SIZE_MB."""
+        """Returns FileTooLarge when screenshot exceeds configured max size."""
         out_file = tmp_path / "huge.png"
         self._register_display(tool, "s1")
-        huge_size = (MAX_SCREENSHOT_SIZE_MB + 1) * 1024 * 1024
+        max_mb = settings.GUI_MAX_SCREENSHOT_SIZE_MB
+        huge_size = (max_mb + 1) * 1024 * 1024
 
         mock_proc = AsyncMock()
         mock_proc.returncode = 0
@@ -339,7 +342,7 @@ class TestGuiScreenshotTool:
 
         result = json.loads(raw)
         assert result["error"] == "FileTooLarge"
-        assert str(MAX_SCREENSHOT_SIZE_MB) in result["message"]
+        assert str(max_mb) in result["message"]
 
     # ------------------------------------------------------------------
     # Negative: session display not registered
@@ -366,6 +369,7 @@ class TestGuiScreenshotTool:
             patch("openroad_mcp.tools.gui._import_available", return_value=True),
             patch("asyncio.create_subprocess_exec", return_value=_make_xvfb_proc()),
             patch("asyncio.sleep", new_callable=AsyncMock),
+            patch("openroad_mcp.tools.gui._wait_for_display", new_callable=AsyncMock, return_value=True),
         ):
             raw = await tool.execute()
 
@@ -504,12 +508,11 @@ class TestPreFlightHelpers:
             assert _import_available() is False
 
     def test_find_free_display_no_locks(self, tmp_path):
-        """Returns first number in range when no lock files exist."""
+        """Returns first number in configured range when no lock files exist."""
         with patch("openroad_mcp.tools.gui.Path") as MockPath:
             MockPath.return_value.exists.return_value = False
-            # _find_free_display expects /tmp/.X{N}-lock not to exist
             num = _find_free_display()
-            assert 42 <= num < 300
+            assert settings.GUI_DISPLAY_START <= num < settings.GUI_DISPLAY_START + 200
 
     def test_get_openroad_exe_from_env(self, tmp_path):
         """OPENROAD_EXE env var is preferred over PATH lookup."""
@@ -545,3 +548,76 @@ class TestPreFlightHelpers:
         ):
             result = _get_openroad_exe()
         assert result is None
+
+
+@pytest.mark.asyncio
+class TestWaitForDisplay:
+    """Tests for the _wait_for_display readiness polling helper."""
+
+    async def test_display_ready_immediately(self):
+        """Returns True when xdpyinfo succeeds on the first poll."""
+        mock_proc = AsyncMock()
+        mock_proc.wait = AsyncMock(return_value=0)
+
+        with (
+            patch("asyncio.create_subprocess_exec", return_value=mock_proc),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            result = await _wait_for_display(42)
+
+        assert result is True
+
+    async def test_display_ready_after_retries(self):
+        """Returns True when xdpyinfo fails initially then succeeds."""
+        call_count = [0]
+
+        async def _make_proc(*args, **kwargs):
+            call_count[0] += 1
+            proc = AsyncMock()
+            # Succeed on 3rd attempt
+            proc.wait = AsyncMock(return_value=0 if call_count[0] >= 3 else 1)
+            return proc
+
+        with (
+            patch("asyncio.create_subprocess_exec", side_effect=_make_proc),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            result = await _wait_for_display(50)
+
+        assert result is True
+        assert call_count[0] >= 3
+
+    async def test_display_timeout(self):
+        """Returns False when display never becomes ready within timeout."""
+        mock_proc = AsyncMock()
+        mock_proc.wait = AsyncMock(return_value=1)  # always fail
+
+        with (
+            patch("asyncio.create_subprocess_exec", return_value=mock_proc),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+            patch.object(settings, "GUI_STARTUP_TIMEOUT_S", 1.0),
+            patch.object(settings, "GUI_STARTUP_POLL_INTERVAL_S", 0.5),
+        ):
+            result = await _wait_for_display(99)
+
+        assert result is False
+
+    async def test_display_handles_oserror(self):
+        """Continues polling if xdpyinfo raises OSError (e.g. not installed)."""
+        call_count = [0]
+
+        async def _make_proc(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] <= 2:
+                raise OSError("No such file")
+            proc = AsyncMock()
+            proc.wait = AsyncMock(return_value=0)
+            return proc
+
+        with (
+            patch("asyncio.create_subprocess_exec", side_effect=_make_proc),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            result = await _wait_for_display(42)
+
+        assert result is True

--- a/tests/tools/test_gui_tool.py
+++ b/tests/tools/test_gui_tool.py
@@ -61,6 +61,7 @@ def _make_xvfb_proc(*, pid: int = 12345, returncode: int | None = None):
     proc = AsyncMock()
     proc.pid = pid
     proc.returncode = returncode
+    proc.terminate = MagicMock()
     return proc
 
 
@@ -1027,7 +1028,7 @@ class TestGuiScreenshotTool:
         assert result["error"] is None
         assert result["image_path"] == str(out_file)
 
-    async def test_explicit_png_format_with_empty_string_output(self, tool, tmp_path):
+    async def test_explicit_png_format_with_empty_string_output(self, tool):
         """image_format='png' with output_path='' uses temp file with .png ext."""
         self._register_display(tool, "s1")
 
@@ -1257,7 +1258,7 @@ class TestPreFlightHelpers:
 
             assert _import_available() is False
 
-    def test_find_free_display_no_locks(self, tmp_path):
+    def test_find_free_display_no_locks(self):
         """Returns first number in configured range when no lock files exist."""
         with patch("openroad_mcp.tools.gui.Path") as MockPath:
             MockPath.return_value.exists.return_value = False

--- a/tests/tools/test_gui_tool.py
+++ b/tests/tools/test_gui_tool.py
@@ -925,6 +925,134 @@ class TestGuiScreenshotTool:
         """cleanup_display is a safe no-op for unknown session ids."""
         tool.cleanup_display("nonexistent")  # should not raise
 
+    # ------------------------------------------------------------------
+    # Empty-string normalisation (MCP Inspector sends "" for blank fields)
+    # ------------------------------------------------------------------
+    async def test_empty_string_image_format_uses_default(self, tool, tmp_path):
+        """Empty string for image_format should use default (jpeg), not error."""
+        out_file = tmp_path / "shot.jpg"
+        self._register_display(tool, "s1")
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_make_import_side_effect()):
+            raw = await tool.execute(session_id="s1", output_path=str(out_file), image_format="")
+
+        result = json.loads(raw)
+        assert result["error"] is None
+        assert result["image_format"] == "jpeg"  # default, not error
+
+    async def test_empty_string_return_mode_uses_default(self, tool, tmp_path):
+        """Empty string for return_mode should default to 'base64'."""
+        out_file = tmp_path / "shot.jpg"
+        self._register_display(tool, "s1")
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_make_import_side_effect()):
+            raw = await tool.execute(session_id="s1", output_path=str(out_file), return_mode="")
+
+        result = json.loads(raw)
+        assert result["error"] is None
+        assert result["return_mode"] == "base64"
+
+    async def test_empty_string_resolution_uses_default(self, tool, tmp_path):
+        """Empty string for resolution should use default, not error."""
+        out_file = tmp_path / "shot.jpg"
+        self._register_display(tool, "s1")
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_make_import_side_effect()):
+            raw = await tool.execute(session_id="s1", output_path=str(out_file), resolution="")
+
+        result = json.loads(raw)
+        assert result["error"] is None
+        # Should use default resolution, not error
+        assert result["resolution"] == settings.GUI_DISPLAY_RESOLUTION
+
+    async def test_empty_string_crop_ignored(self, tool, tmp_path):
+        """Empty string for crop should be treated as no crop."""
+        out_file = tmp_path / "shot.jpg"
+        self._register_display(tool, "s1")
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_make_import_side_effect()):
+            raw = await tool.execute(session_id="s1", output_path=str(out_file), crop="")
+
+        result = json.loads(raw)
+        assert result["error"] is None
+
+    # ------------------------------------------------------------------
+    # output_path: parent directory creation & extension correction
+    # ------------------------------------------------------------------
+    async def test_output_path_creates_parent_dirs(self, tool, tmp_path):
+        """output_path with non-existent parent directory should create it."""
+        nested_dir = tmp_path / "deep" / "nested" / "dir"
+        out_file = nested_dir / "screenshot.jpg"
+        self._register_display(tool, "s1")
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_make_import_side_effect()):
+            raw = await tool.execute(session_id="s1", output_path=str(out_file))
+
+        result = json.loads(raw)
+        assert result["error"] is None
+        assert nested_dir.exists()
+        assert Path(result["image_path"]).exists()
+
+    async def test_output_path_extension_corrected_for_format(self, tool, tmp_path):
+        """output_path with wrong extension gets corrected to match image_format."""
+        out_file = tmp_path / "screenshot.jpg"
+        self._register_display(tool, "s1")
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_make_import_side_effect()):
+            raw = await tool.execute(
+                session_id="s1",
+                output_path=str(out_file),
+                image_format="png",
+            )
+
+        result = json.loads(raw)
+        assert result["error"] is None
+        assert result["image_format"] == "png"
+        # Extension should be corrected to .png
+        assert result["image_path"].endswith(".png")
+
+    async def test_output_path_correct_extension_preserved(self, tool, tmp_path):
+        """output_path with correct extension is preserved as-is."""
+        out_file = tmp_path / "screenshot.png"
+        self._register_display(tool, "s1")
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_make_import_side_effect()):
+            raw = await tool.execute(
+                session_id="s1",
+                output_path=str(out_file),
+                image_format="png",
+            )
+
+        result = json.loads(raw)
+        assert result["error"] is None
+        assert result["image_path"] == str(out_file)
+
+    async def test_explicit_png_format_with_empty_string_output(self, tool, tmp_path):
+        """image_format='png' with output_path='' uses temp file with .png ext."""
+        self._register_display(tool, "s1")
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_make_import_side_effect()):
+            raw = await tool.execute(session_id="s1", output_path="", image_format="png")
+
+        result = json.loads(raw)
+        assert result["error"] is None
+        assert result["image_format"] == "png"
+        assert result["image_path"].endswith(".png")
+
+    async def test_format_inferred_from_output_path_extension(self, tool, tmp_path):
+        """When image_format is omitted, format is inferred from output_path ext."""
+        out_file = tmp_path / "my_screenshot.png"
+        self._register_display(tool, "s1")
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_make_import_side_effect()):
+            raw = await tool.execute(session_id="s1", output_path=str(out_file))
+
+        result = json.loads(raw)
+        assert result["error"] is None
+        assert result["image_format"] == "png"
+        assert result["image_path"] == str(out_file)
+        assert out_file.exists()
+
 
 # ------------------------------------------------------------------
 # Standalone helper tests

--- a/tests/tools/test_gui_tool.py
+++ b/tests/tools/test_gui_tool.py
@@ -14,8 +14,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from openroad_mcp.config.settings import settings
 from openroad_mcp.tools.gui import (
-    DEFAULT_DISPLAY_RESOLUTION,
     MAX_SCREENSHOT_SIZE_MB,
     GuiScreenshotTool,
     _find_free_display,
@@ -153,7 +153,7 @@ class TestGuiScreenshotTool:
             raw = await tool.execute(session_id="s1", output_path=str(out_file))
 
         result = json.loads(raw)
-        assert result["resolution"] == DEFAULT_DISPLAY_RESOLUTION
+        assert result["resolution"] == settings.GUI_DISPLAY_RESOLUTION
 
     async def test_custom_resolution(self, tool, mock_manager, tmp_path):
         """Custom resolution is threaded through to result and Xvfb start."""

--- a/tests/tools/test_gui_tool.py
+++ b/tests/tools/test_gui_tool.py
@@ -21,6 +21,7 @@ from openroad_mcp.tools.gui import (
     GuiScreenshotTool,
     _find_free_display,
     _wait_for_display,
+    _wait_for_gui_ready,
 )
 
 # Minimal valid PNG (1×1 pixel, RGBA)
@@ -176,6 +177,7 @@ class TestGuiScreenshotTool:
             patch("asyncio.create_subprocess_exec", side_effect=_create_sub),
             patch("asyncio.sleep", new_callable=AsyncMock),
             patch("openroad_mcp.tools.gui._wait_for_display", new_callable=AsyncMock, return_value=True),
+            patch("openroad_mcp.tools.gui._wait_for_gui_ready", new_callable=AsyncMock, return_value=True),
         ):
             raw = await tool.execute(output_path=str(out_file))
 
@@ -228,6 +230,7 @@ class TestGuiScreenshotTool:
             patch("asyncio.create_subprocess_exec", side_effect=_create_sub),
             patch("asyncio.sleep", new_callable=AsyncMock),
             patch("openroad_mcp.tools.gui._wait_for_display", new_callable=AsyncMock, return_value=True),
+            patch("openroad_mcp.tools.gui._wait_for_gui_ready", new_callable=AsyncMock, return_value=True),
         ):
             raw = await tool.execute(resolution="1920x1080x24", output_path=str(out_file))
 
@@ -404,6 +407,7 @@ class TestGuiScreenshotTool:
             patch("asyncio.create_subprocess_exec", return_value=_make_xvfb_proc()),
             patch("asyncio.sleep", new_callable=AsyncMock),
             patch("openroad_mcp.tools.gui._wait_for_display", new_callable=AsyncMock, return_value=True),
+            patch("openroad_mcp.tools.gui._wait_for_gui_ready", new_callable=AsyncMock, return_value=True),
         ):
             raw = await tool.execute()
 
@@ -1066,5 +1070,99 @@ class TestWaitForDisplay:
             patch("asyncio.sleep", new_callable=AsyncMock),
         ):
             result = await _wait_for_display(42)
+
+        assert result is True
+
+
+@pytest.mark.asyncio
+class TestWaitForGuiReady:
+    """Tests for the _wait_for_gui_ready window-detection helper."""
+
+    def _make_xwininfo_proc(self, stdout_text: str, *, returncode: int = 0):
+        """Build a mock subprocess for xwininfo that returns *stdout_text*."""
+        proc = AsyncMock()
+        proc.returncode = returncode
+        proc.communicate = AsyncMock(return_value=(stdout_text.encode("utf-8"), b""))
+        return proc
+
+    # Example xwininfo output with no children (just root)
+    _NO_CHILDREN = """\
+xwininfo: Window id: 0x3e (the root window) "root"
+
+  Root window id: 0x3e (the root window) "root"
+  Parent window id: 0x0 (none)
+     0 children.
+"""
+
+    # Example xwininfo output with OpenROAD window present
+    _HAS_CHILDREN = """\
+xwininfo: Window id: 0x3e (the root window) "root"
+
+  Root window id: 0x3e (the root window) "root"
+  Parent window id: 0x0 (none)
+     1 child:
+     0x1400001 (has no name): ("openroad" "OpenROAD")  1280x1024+0+0  +0+0
+"""
+
+    async def test_gui_ready_immediately(self):
+        """Returns True when a child window is found on the first poll."""
+        proc = self._make_xwininfo_proc(self._HAS_CHILDREN)
+
+        with (
+            patch("asyncio.create_subprocess_exec", return_value=proc),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            result = await _wait_for_gui_ready(42)
+
+        assert result is True
+
+    async def test_gui_ready_after_retries(self):
+        """Returns True when children appear after a few polls."""
+        call_count = [0]
+
+        async def _make_proc(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] < 3:
+                return self._make_xwininfo_proc(self._NO_CHILDREN)
+            return self._make_xwininfo_proc(self._HAS_CHILDREN)
+
+        with (
+            patch("asyncio.create_subprocess_exec", side_effect=_make_proc),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            result = await _wait_for_gui_ready(50)
+
+        assert result is True
+        assert call_count[0] >= 3
+
+    async def test_gui_ready_timeout(self):
+        """Returns False when no child window appears within timeout."""
+        proc = self._make_xwininfo_proc(self._NO_CHILDREN)
+
+        with (
+            patch("asyncio.create_subprocess_exec", return_value=proc),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+            patch.object(settings, "GUI_APP_READY_TIMEOUT_S", 1.0),
+            patch.object(settings, "GUI_APP_READY_POLL_INTERVAL_S", 0.5),
+        ):
+            result = await _wait_for_gui_ready(99)
+
+        assert result is False
+
+    async def test_gui_ready_handles_oserror(self):
+        """Continues polling when xwininfo raises OSError."""
+        call_count = [0]
+
+        async def _make_proc(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] <= 2:
+                raise OSError("No such file")
+            return self._make_xwininfo_proc(self._HAS_CHILDREN)
+
+        with (
+            patch("asyncio.create_subprocess_exec", side_effect=_make_proc),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            result = await _wait_for_gui_ready(42)
 
         assert result is True

--- a/tests/tools/test_gui_tool.py
+++ b/tests/tools/test_gui_tool.py
@@ -1273,7 +1273,14 @@ class TestPreFlightHelpers:
         with patch("openroad_mcp.tools.gui.Path") as MockPath:
             MockPath.return_value.exists.return_value = False
             num = _find_free_display()
-            assert settings.GUI_DISPLAY_START <= num < settings.GUI_DISPLAY_START + 200
+            assert num == settings.GUI_DISPLAY_START
+
+    def test_find_free_display_all_occupied(self):
+        """Returns a fallback display >= GUI_DISPLAY_END when all are occupied."""
+        with patch("openroad_mcp.tools.gui.Path") as MockPath:
+            MockPath.return_value.exists.return_value = True
+            num = _find_free_display()
+            assert num >= settings.GUI_DISPLAY_END
 
     def test_get_openroad_exe_from_env(self, tmp_path):
         """OPENROAD_EXE env var is preferred over PATH lookup."""

--- a/tests/tools/test_gui_tool.py
+++ b/tests/tools/test_gui_tool.py
@@ -1,31 +1,27 @@
 """Unit tests for GuiScreenshotTool implementation.
 
-Tests all code paths using mocked dependencies (no xvfb/OpenROAD required).
-Integration tests that exercise the real GUI are in tests/integration/test_gui.py.
+Tests all code paths using mocked dependencies (no Xvfb/OpenROAD/ImageMagick
+required).  Integration tests that exercise the real GUI are in
+tests/integration/test_gui.py.
 """
 
+import asyncio
 import base64
 import json
 import tempfile
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from openroad_mcp.core.models import InteractiveExecResult
-from openroad_mcp.interactive.models import (
-    SessionError,
-    SessionNotFoundError,
-    SessionTerminatedError,
-)
 from openroad_mcp.tools.gui import (
     DEFAULT_DISPLAY_RESOLUTION,
-    IMAGE_CAPTURE_TIMEOUT_MS,
     MAX_SCREENSHOT_SIZE_MB,
     GuiScreenshotTool,
+    _find_free_display,
 )
 
-# Minimal valid PNG (1x1 pixel, RGBA)
+# Minimal valid PNG (1×1 pixel, RGBA)
 _MINIMAL_PNG = (
     b"\x89PNG\r\n\x1a\n"  # signature
     b"\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
@@ -35,415 +31,394 @@ _MINIMAL_PNG = (
 )
 
 
+# ------------------------------------------------------------------
+# Helpers: mock ``import`` and ``Xvfb`` subprocesses
+# ------------------------------------------------------------------
+
+
+def _make_import_proc(image_path: Path | str | None, *, returncode: int = 0, stderr: bytes = b""):
+    """Return a mock that behaves like ``asyncio.create_subprocess_exec``
+    created for the ``import`` command.  When *image_path* is not None and
+    *returncode* is 0 the mock writes ``_MINIMAL_PNG`` to that path."""
+    proc = AsyncMock()
+    proc.returncode = returncode
+
+    async def _communicate():
+        if returncode == 0 and image_path is not None:
+            Path(image_path).write_bytes(_MINIMAL_PNG)
+        return b"", stderr
+
+    proc.communicate = _communicate
+    proc.kill = MagicMock()
+    return proc
+
+
+def _make_xvfb_proc(*, pid: int = 12345, returncode: int | None = None):
+    """Return a mock Xvfb subprocess.  *returncode=None* means still running."""
+    proc = AsyncMock()
+    proc.pid = pid
+    proc.returncode = returncode
+    return proc
+
+
 @pytest.mark.asyncio
 class TestGuiScreenshotTool:
     """Test suite for GuiScreenshotTool."""
 
     @pytest.fixture
     def mock_manager(self):
-        """Create a mock OpenROADManager."""
         return AsyncMock()
 
     @pytest.fixture
     def tool(self, mock_manager) -> GuiScreenshotTool:
-        """Create GuiScreenshotTool with mock manager."""
         return GuiScreenshotTool(mock_manager)
 
+    # Helper: register a display for an existing session
+    def _register_display(self, tool: GuiScreenshotTool, session_id: str, display: int = 42) -> None:
+        tool._session_displays[session_id] = display
+        tool._xvfb_pids[session_id] = 99999
+
     # ------------------------------------------------------------------
-    # Positive: successful screenshot (happy path)
+    # Positive: successful screenshot (happy path, existing session)
     # ------------------------------------------------------------------
-    async def test_successful_screenshot(self, tool, mock_manager, tmp_path):
-        """Full happy path: existing session → save_image → PNG returned."""
+    async def test_successful_screenshot(self, tool, tmp_path):
+        """Full happy path: existing session → import -window root → PNG."""
         out_file = tmp_path / "screenshot.png"
+        self._register_display(tool, "gui-sess-1")
 
-        mock_result = InteractiveExecResult(
-            output="",
-            session_id="gui-sess-1",
-            timestamp="2024-01-01T00:00:00Z",
-            execution_time=0.1,
-            command_count=1,
-        )
+        mock_proc = _make_import_proc(out_file)
 
-        # Simulate gui::save_image writing the file during execute_command
-        def _write_and_return(*_args, **_kwargs):
-            out_file.write_bytes(_MINIMAL_PNG)
-            return mock_result
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            raw = await tool.execute(session_id="gui-sess-1", output_path=str(out_file))
 
-        mock_manager.execute_command.side_effect = _write_and_return
-
-        raw = await tool.execute(session_id="gui-sess-1", output_path=str(out_file))
         result = json.loads(raw)
-
         assert result["error"] is None
         assert result["session_id"] == "gui-sess-1"
         assert result["image_format"] == "png"
         assert result["size_bytes"] == len(_MINIMAL_PNG)
         assert result["message"] == "Screenshot captured successfully."
+        assert base64.b64decode(result["image_data"]) == _MINIMAL_PNG
 
-        # Verify base64 round-trips correctly
-        decoded = base64.b64decode(result["image_data"])
-        assert decoded == _MINIMAL_PNG
-
+    # ------------------------------------------------------------------
+    # Positive: auto-session creation (Xvfb + OpenROAD)
+    # ------------------------------------------------------------------
     async def test_successful_screenshot_auto_session(self, tool, mock_manager, tmp_path):
-        """When no session_id is given, a new session is created via xvfb-run."""
+        """When no session_id is given, Xvfb + OpenROAD are started."""
         out_file = tmp_path / "auto.png"
+        mock_manager.create_session.return_value = "auto-sess"
 
-        mock_manager.create_session.return_value = "auto-session"
+        xvfb_proc = _make_xvfb_proc()
 
-        mock_result = InteractiveExecResult(
-            output="",
-            session_id="auto-session",
-            timestamp="2024-01-01T00:00:00Z",
-            execution_time=0.2,
-            command_count=1,
-        )
-        mock_manager.execute_command.side_effect = lambda *a, **kw: _side_effect_write(out_file, mock_result)
+        # First call → Xvfb, second call → import
+        calls = [0]
 
-        with patch("openroad_mcp.tools.gui._xvfb_available", return_value=True):
-            with patch("asyncio.sleep", new_callable=AsyncMock):  # skip startup delay
-                raw = await tool.execute(output_path=str(out_file))
+        async def _create_sub(*args, **kwargs):
+            calls[0] += 1
+            if calls[0] == 1:
+                # Xvfb
+                return xvfb_proc
+            # import
+            return _make_import_proc(out_file)
+
+        with (
+            patch("openroad_mcp.tools.gui._xvfb_available", return_value=True),
+            patch("openroad_mcp.tools.gui._openroad_available", return_value=True),
+            patch("openroad_mcp.tools.gui._import_available", return_value=True),
+            patch("asyncio.create_subprocess_exec", side_effect=_create_sub),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            raw = await tool.execute(output_path=str(out_file))
 
         result = json.loads(raw)
         assert result["error"] is None
-        assert result["session_id"] == "auto-session"
+        assert result["session_id"] == "auto-sess"
 
-        # Verify xvfb-run command was passed to create_session
-        call_args = mock_manager.create_session.call_args
-        # create_session is called with keyword arg 'command' (a list)
-        cmd_list = call_args.kwargs.get("command", call_args.args[0] if call_args.args else [])
-        assert "xvfb-run" in cmd_list
-        assert "-gui" in cmd_list
+        # Verify create_session used openroad -gui (not xvfb-run)
+        call_kw = mock_manager.create_session.call_args.kwargs
+        cmd = call_kw.get("command", [])
+        assert cmd == ["openroad", "-gui", "-no_init"]
+        assert "DISPLAY" in call_kw.get("env", {})
 
-    async def test_default_resolution_and_timeout(self, tool, mock_manager, tmp_path):
-        """Defaults for resolution and timeout are applied when not specified."""
+    # ------------------------------------------------------------------
+    # Defaults
+    # ------------------------------------------------------------------
+    async def test_default_resolution_and_timeout(self, tool, tmp_path):
+        """Defaults for resolution and timeout are applied."""
         out_file = tmp_path / "defaults.png"
+        self._register_display(tool, "s1")
 
-        mock_result = InteractiveExecResult(
-            output="",
-            session_id="s1",
-            timestamp="2024-01-01T00:00:00Z",
-            execution_time=0.1,
-            command_count=1,
-        )
-        mock_manager.execute_command.side_effect = lambda *a, **kw: _side_effect_write(out_file, mock_result)
+        mock_proc = _make_import_proc(out_file)
 
-        raw = await tool.execute(session_id="s1", output_path=str(out_file))
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            raw = await tool.execute(session_id="s1", output_path=str(out_file))
+
         result = json.loads(raw)
-
         assert result["resolution"] == DEFAULT_DISPLAY_RESOLUTION
-        # execute_command should receive the default timeout
-        call_args = mock_manager.execute_command.call_args.args
-        assert call_args[2] == IMAGE_CAPTURE_TIMEOUT_MS
 
     async def test_custom_resolution(self, tool, mock_manager, tmp_path):
-        """Custom resolution is threaded through to the result."""
-        out_file = tmp_path / "custom_res.png"
+        """Custom resolution is threaded through to result and Xvfb start."""
+        out_file = tmp_path / "res.png"
+        mock_manager.create_session.return_value = "res-sess"
 
-        mock_result = InteractiveExecResult(
-            output="",
-            session_id="s1",
-            timestamp="2024-01-01T00:00:00Z",
-            execution_time=0.1,
-            command_count=1,
-        )
-        mock_manager.execute_command.side_effect = lambda *a, **kw: _side_effect_write(
-            out_file,
-            mock_result,
-        )
+        xvfb_proc = _make_xvfb_proc()
+        calls = [0]
 
-        raw = await tool.execute(
-            session_id="s1",
-            resolution="1920x1080x24",
-            output_path=str(out_file),
-        )
+        async def _create_sub(*args, **kwargs):
+            calls[0] += 1
+            if calls[0] == 1:
+                # Xvfb – verify resolution is passed
+                assert "1920x1080x24" in args
+                return xvfb_proc
+            return _make_import_proc(out_file)
+
+        with (
+            patch("openroad_mcp.tools.gui._xvfb_available", return_value=True),
+            patch("openroad_mcp.tools.gui._openroad_available", return_value=True),
+            patch("openroad_mcp.tools.gui._import_available", return_value=True),
+            patch("asyncio.create_subprocess_exec", side_effect=_create_sub),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            raw = await tool.execute(resolution="1920x1080x24", output_path=str(out_file))
+
         result = json.loads(raw)
-
         assert result["resolution"] == "1920x1080x24"
 
-    async def test_custom_timeout(self, tool, mock_manager, tmp_path):
-        """Custom timeout_ms is forwarded to execute_command."""
+    async def test_custom_timeout(self, tool, tmp_path):
+        """Custom timeout_ms governs the import subprocess timeout."""
         out_file = tmp_path / "timeout.png"
+        self._register_display(tool, "s1")
 
-        mock_result = InteractiveExecResult(
-            output="",
-            session_id="s1",
-            timestamp="2024-01-01T00:00:00Z",
-            execution_time=0.1,
-            command_count=1,
-        )
-        mock_manager.execute_command.side_effect = lambda *a, **kw: _side_effect_write(
-            out_file,
-            mock_result,
-        )
+        mock_proc = _make_import_proc(out_file)
 
-        await tool.execute(session_id="s1", output_path=str(out_file), timeout_ms=20_000)
+        with (
+            patch("asyncio.create_subprocess_exec", return_value=mock_proc),
+            patch("asyncio.wait_for", wraps=asyncio.wait_for) as mock_wait,
+        ):
+            await tool.execute(session_id="s1", output_path=str(out_file), timeout_ms=20_000)
 
-        call_args = mock_manager.execute_command.call_args.args
-        assert call_args[2] == 20_000
+        # wait_for should have been called with timeout=20.0
+        _, kwargs = mock_wait.call_args
+        assert kwargs.get("timeout") == 20.0
 
     # ------------------------------------------------------------------
     # Positive: temp file path generation
     # ------------------------------------------------------------------
-    async def test_temp_file_used_when_no_output_path(self, tool, mock_manager):
+    async def test_temp_file_used_when_no_output_path(self, tool):
         """When output_path is omitted a temp file under /tmp is used."""
-        mock_result = InteractiveExecResult(
-            output="",
-            session_id="s1",
-            timestamp="2024-01-01T00:00:00Z",
-            execution_time=0.1,
-            command_count=1,
-        )
+        self._register_display(tool, "s1")
 
-        # We need the temp file path to write the PNG into
-        written_path: list[Path] = []
+        captured_path: list[str] = []
 
-        async def _capture_path(sid, cmd, timeout):
-            # Extract path from the Tcl command
-            # e.g.  gui::save_image "/tmp/openroad_gui_xxxx.png"
-            path_str = cmd.split('"')[1]
-            p = Path(path_str)
-            p.write_bytes(_MINIMAL_PNG)
-            written_path.append(p)
-            return mock_result
+        async def _capture(*args, **kwargs):
+            # The 4th positional arg to import is the image path
+            path_str = args[3]
+            captured_path.append(path_str)
+            return _make_import_proc(path_str)
 
-        mock_manager.execute_command.side_effect = _capture_path
+        with patch("asyncio.create_subprocess_exec", side_effect=_capture):
+            raw = await tool.execute(session_id="s1")
 
-        raw = await tool.execute(session_id="s1")
         result = json.loads(raw)
-
         assert result["error"] is None
         assert result["image_path"].startswith(tempfile.gettempdir())
         assert result["image_path"].endswith(".png")
 
         # Cleanup
-        if written_path:
-            written_path[0].unlink(missing_ok=True)
+        for p in captured_path:
+            Path(p).unlink(missing_ok=True)
 
     # ------------------------------------------------------------------
-    # Negative: xvfb not installed
+    # Negative: pre-flight checks
     # ------------------------------------------------------------------
     async def test_xvfb_not_found_error(self, tool):
-        """Returns structured error when xvfb-run is missing."""
+        """Returns structured error when Xvfb is missing."""
         with patch("openroad_mcp.tools.gui._xvfb_available", return_value=False):
             raw = await tool.execute()
-            result = json.loads(raw)
-
+        result = json.loads(raw)
         assert result["error"] == "XvfbNotFound"
-        assert "xvfb-run" in result["message"]
+        assert "xvfb" in result["message"].lower()
+
+    async def test_openroad_not_found_error(self, tool):
+        """Returns structured error when openroad is missing."""
+        with (
+            patch("openroad_mcp.tools.gui._xvfb_available", return_value=True),
+            patch("openroad_mcp.tools.gui._openroad_available", return_value=False),
+        ):
+            raw = await tool.execute()
+        result = json.loads(raw)
+        assert result["error"] == "OpenROADNotFound"
+        assert "openroad" in result["message"].lower()
+
+    async def test_import_not_found_error(self, tool):
+        """Returns structured error when ImageMagick import is missing."""
+        with (
+            patch("openroad_mcp.tools.gui._xvfb_available", return_value=True),
+            patch("openroad_mcp.tools.gui._openroad_available", return_value=True),
+            patch("openroad_mcp.tools.gui._import_available", return_value=False),
+        ):
+            raw = await tool.execute()
+        result = json.loads(raw)
+        assert result["error"] == "ImportNotFound"
+        assert "imagemagick" in result["message"].lower()
 
     # ------------------------------------------------------------------
-    # Negative: screenshot file missing / empty
+    # Negative: import subprocess failures
     # ------------------------------------------------------------------
-    async def test_screenshot_failed_file_missing(self, tool, mock_manager, tmp_path):
-        """Returns ScreenshotFailed when gui::save_image produces no file."""
+    async def test_screenshot_failed_import_error(self, tool, tmp_path):
+        """Returns ScreenshotFailed when import exits with non-zero rc."""
+        out_file = tmp_path / "fail.png"
+        self._register_display(tool, "s1")
+
+        mock_proc = _make_import_proc(None, returncode=1, stderr=b"import: unable to open X server")
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            raw = await tool.execute(session_id="s1", output_path=str(out_file))
+
+        result = json.loads(raw)
+        assert result["error"] == "ScreenshotFailed"
+        assert "rc=1" in result["message"]
+
+    async def test_screenshot_failed_import_timeout(self, tool, tmp_path):
+        """Returns ScreenshotFailed when import subprocess times out."""
+        out_file = tmp_path / "slow.png"
+        self._register_display(tool, "s1")
+
+        mock_proc = AsyncMock()
+        mock_proc.returncode = None
+        mock_proc.kill = MagicMock()
+
+        async def _hang():
+            await asyncio.sleep(999)
+            return b"", b""
+
+        mock_proc.communicate = _hang
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            raw = await tool.execute(session_id="s1", output_path=str(out_file), timeout_ms=200)
+
+        result = json.loads(raw)
+        assert result["error"] == "ScreenshotFailed"
+        assert "timed out" in result["message"].lower()
+        mock_proc.kill.assert_called_once()
+
+    async def test_screenshot_failed_file_missing(self, tool, tmp_path):
+        """Returns ScreenshotFailed when import exits OK but writes no file."""
         out_file = tmp_path / "missing.png"
+        self._register_display(tool, "s1")
 
-        mock_result = InteractiveExecResult(
-            output="some gui output",
-            session_id="s1",
-            timestamp="2024-01-01T00:00:00Z",
-            execution_time=0.1,
-            command_count=1,
-        )
-        # Don't write anything — simulate gui::save_image failure
-        mock_manager.execute_command.return_value = mock_result
+        # import succeeds but writes nothing
+        mock_proc = _make_import_proc(None, returncode=0)
 
-        with patch("openroad_mcp.tools.gui._FILE_POLL_MAX_WAIT", 0.1):  # speed up polling
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
             raw = await tool.execute(session_id="s1", output_path=str(out_file))
 
         result = json.loads(raw)
-
         assert result["error"] == "ScreenshotFailed"
-        assert "not created" in result["message"] or "empty" in result["message"]
-        assert result["session_id"] == "s1"
-
-    async def test_screenshot_failed_file_empty(self, tool, mock_manager, tmp_path):
-        """Returns ScreenshotFailed when gui::save_image writes a 0-byte file."""
-        out_file = tmp_path / "empty.png"
-
-        mock_result = InteractiveExecResult(
-            output="gui output",
-            session_id="s1",
-            timestamp="2024-01-01T00:00:00Z",
-            execution_time=0.1,
-            command_count=1,
-        )
-        mock_manager.execute_command.return_value = mock_result
-
-        # Write a zero-byte file — simulates partial write
-        out_file.write_bytes(b"")
-
-        with patch("openroad_mcp.tools.gui._FILE_POLL_MAX_WAIT", 0.1):
-            raw = await tool.execute(session_id="s1", output_path=str(out_file))
-
-        result = json.loads(raw)
-
-        assert result["error"] == "ScreenshotFailed"
-        assert result["session_id"] == "s1"
+        assert "not created" in result["message"]
 
     # ------------------------------------------------------------------
     # Negative: file too large
     # ------------------------------------------------------------------
-    async def test_file_too_large_error(self, tool, mock_manager, tmp_path):
+    async def test_file_too_large_error(self, tool, tmp_path):
         """Returns FileTooLarge when screenshot exceeds MAX_SCREENSHOT_SIZE_MB."""
         out_file = tmp_path / "huge.png"
-
-        # Create a file that exceeds the size limit.
-        # The side_effect writes a huge file *during* execute_command,
-        # so it exists when the polling loop checks.
+        self._register_display(tool, "s1")
         huge_size = (MAX_SCREENSHOT_SIZE_MB + 1) * 1024 * 1024
 
-        mock_result = InteractiveExecResult(
-            output="",
-            session_id="s1",
-            timestamp="2024-01-01T00:00:00Z",
-            execution_time=0.1,
-            command_count=1,
-        )
+        mock_proc = AsyncMock()
+        mock_proc.returncode = 0
 
-        def _write_huge(*_a, **_kw):
+        async def _big():
             out_file.write_bytes(b"\x00" * huge_size)
-            return mock_result
+            return b"", b""
 
-        mock_manager.execute_command.side_effect = _write_huge
+        mock_proc.communicate = _big
 
-        raw = await tool.execute(session_id="s1", output_path=str(out_file))
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            raw = await tool.execute(session_id="s1", output_path=str(out_file))
+
         result = json.loads(raw)
-
         assert result["error"] == "FileTooLarge"
         assert str(MAX_SCREENSHOT_SIZE_MB) in result["message"]
 
     # ------------------------------------------------------------------
-    # Negative: session not found
+    # Negative: session display not registered
     # ------------------------------------------------------------------
-    async def test_session_not_found_error(self, tool, mock_manager):
-        """Returns SessionNotFound for non-existent session_id."""
-        mock_manager.execute_command.side_effect = SessionNotFoundError("not found")
-
-        raw = await tool.execute(session_id="ghost-session")
+    async def test_session_without_display(self, tool):
+        """Returns error when session_id has no registered display."""
+        raw = await tool.execute(session_id="unknown-sess")
         result = json.loads(raw)
-
         assert result["error"] == "SessionNotFound"
-        assert result["session_id"] == "ghost-session"
-        assert "not found" in result["message"]
+        assert "no associated X display" in result["message"]
 
     # ------------------------------------------------------------------
-    # Negative: session terminated
+    # Negative: session errors during auto-session creation
     # ------------------------------------------------------------------
-    async def test_session_terminated_error(self, tool, mock_manager):
-        """Returns SessionError when session has terminated."""
-        mock_manager.execute_command.side_effect = SessionTerminatedError("session has been terminated")
+    async def test_session_error_on_create(self, tool, mock_manager):
+        """Returns SessionError when create_session raises."""
+        from openroad_mcp.interactive.models import SessionError as SE
 
-        raw = await tool.execute(session_id="dead-session")
+        mock_manager.create_session.side_effect = SE("boom")
+
+        with (
+            patch("openroad_mcp.tools.gui._xvfb_available", return_value=True),
+            patch("openroad_mcp.tools.gui._openroad_available", return_value=True),
+            patch("openroad_mcp.tools.gui._import_available", return_value=True),
+            patch("asyncio.create_subprocess_exec", return_value=_make_xvfb_proc()),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            raw = await tool.execute()
+
         result = json.loads(raw)
-
         assert result["error"] == "SessionError"
-        assert result["session_id"] == "dead-session"
-
-    async def test_session_error(self, tool, mock_manager):
-        """Returns SessionError for generic session errors."""
-        mock_manager.execute_command.side_effect = SessionError("something went wrong")
-
-        raw = await tool.execute(session_id="bad-session")
-        result = json.loads(raw)
-
-        assert result["error"] == "SessionError"
-        assert "something went wrong" in result["message"]
+        assert "boom" in result["message"]
 
     # ------------------------------------------------------------------
     # Negative: unexpected exception
     # ------------------------------------------------------------------
-    async def test_unexpected_error(self, tool, mock_manager):
+    async def test_unexpected_error(self, tool):
         """Returns UnexpectedError for unhandled exceptions."""
-        mock_manager.execute_command.side_effect = RuntimeError("kaboom")
+        self._register_display(tool, "s1")
 
-        raw = await tool.execute(session_id="s1")
+        with patch("asyncio.create_subprocess_exec", side_effect=RuntimeError("kaboom")):
+            raw = await tool.execute(session_id="s1")
+
         result = json.loads(raw)
-
         assert result["error"] == "UnexpectedError"
         assert "kaboom" in result["message"]
 
     # ------------------------------------------------------------------
-    # Edge: stale file is cleaned before screenshot
+    # Edge: stale file is cleaned before capture
     # ------------------------------------------------------------------
-    async def test_stale_file_removed_before_capture(self, tool, mock_manager, tmp_path):
-        """A stale file at the output path is removed before gui::save_image."""
+    async def test_stale_file_removed_before_capture(self, tool, tmp_path):
+        """A stale file at the output path is removed before import."""
         out_file = tmp_path / "stale.png"
         out_file.write_bytes(b"old data")
+        self._register_display(tool, "s1")
 
-        mock_result = InteractiveExecResult(
-            output="",
-            session_id="s1",
-            timestamp="2024-01-01T00:00:00Z",
-            execution_time=0.1,
-            command_count=1,
-        )
-        mock_manager.execute_command.side_effect = lambda *a, **kw: _side_effect_write(
-            out_file,
-            mock_result,
-        )
+        mock_proc = _make_import_proc(out_file)
 
-        raw = await tool.execute(session_id="s1", output_path=str(out_file))
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            raw = await tool.execute(session_id="s1", output_path=str(out_file))
+
         result = json.loads(raw)
-
         assert result["error"] is None
-        # The image_data should be _MINIMAL_PNG, not "old data"
-        decoded = base64.b64decode(result["image_data"])
-        assert decoded == _MINIMAL_PNG
-
-    # ------------------------------------------------------------------
-    # Edge: polling discovers file on a later iteration
-    # ------------------------------------------------------------------
-    async def test_polling_waits_for_file(self, tool, mock_manager, tmp_path):
-        """File appears after a delay — polling loop picks it up."""
-        import asyncio
-
-        out_file = tmp_path / "delayed.png"
-
-        mock_result = InteractiveExecResult(
-            output="",
-            session_id="s1",
-            timestamp="2024-01-01T00:00:00Z",
-            execution_time=0.1,
-            command_count=1,
-        )
-        mock_manager.execute_command.return_value = mock_result
-
-        # Schedule the file to appear after 0.3s
-        async def _delayed_write():
-            await asyncio.sleep(0.3)
-            out_file.write_bytes(_MINIMAL_PNG)
-
-        asyncio.create_task(_delayed_write())
-
-        raw = await tool.execute(session_id="s1", output_path=str(out_file))
-        result = json.loads(raw)
-
-        assert result["error"] is None
-        assert result["size_bytes"] == len(_MINIMAL_PNG)
+        assert base64.b64decode(result["image_data"]) == _MINIMAL_PNG
 
     # ------------------------------------------------------------------
     # Result structure: all expected fields present
     # ------------------------------------------------------------------
-    async def test_result_contains_all_fields(self, tool, mock_manager, tmp_path):
+    async def test_result_contains_all_fields(self, tool, tmp_path):
         """Successful result includes every GuiScreenshotResult field."""
         out_file = tmp_path / "fields.png"
+        self._register_display(tool, "s1")
 
-        mock_result = InteractiveExecResult(
-            output="",
-            session_id="s1",
-            timestamp="2024-01-01T00:00:00Z",
-            execution_time=0.1,
-            command_count=1,
-        )
-        mock_manager.execute_command.side_effect = lambda *a, **kw: _side_effect_write(
-            out_file,
-            mock_result,
-        )
+        mock_proc = _make_import_proc(out_file)
 
-        raw = await tool.execute(session_id="s1", output_path=str(out_file))
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            raw = await tool.execute(session_id="s1", output_path=str(out_file))
+
         result = json.loads(raw)
-
         expected_keys = {
             "session_id",
             "image_data",
@@ -455,33 +430,83 @@ class TestGuiScreenshotTool:
             "message",
             "error",
         }
-        assert expected_keys.issubset(result.keys()), f"Missing keys: {expected_keys - result.keys()}"
+        assert expected_keys.issubset(result.keys()), f"Missing: {expected_keys - result.keys()}"
+
+    # ------------------------------------------------------------------
+    # Xvfb start failure
+    # ------------------------------------------------------------------
+    async def test_xvfb_start_failed(self, tool):
+        """Returns error when Xvfb exits immediately."""
+        xvfb_proc = _make_xvfb_proc(returncode=1)  # exited immediately
+
+        with (
+            patch("openroad_mcp.tools.gui._xvfb_available", return_value=True),
+            patch("openroad_mcp.tools.gui._openroad_available", return_value=True),
+            patch("openroad_mcp.tools.gui._import_available", return_value=True),
+            patch("asyncio.create_subprocess_exec", return_value=xvfb_proc),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            raw = await tool.execute()
+
+        result = json.loads(raw)
+        assert result["error"] == "XvfbStartFailed"
+
+    # ------------------------------------------------------------------
+    # cleanup_display helper
+    # ------------------------------------------------------------------
+    async def test_cleanup_display_kills_xvfb(self, tool):
+        """cleanup_display sends SIGTERM to the stored Xvfb PID."""
+        tool._session_displays["s1"] = 42
+        tool._xvfb_pids["s1"] = 12345
+
+        with patch("os.kill") as mock_kill:
+            tool.cleanup_display("s1")
+
+        mock_kill.assert_called_once()
+        assert "s1" not in tool._session_displays
+        assert "s1" not in tool._xvfb_pids
+
+    async def test_cleanup_display_noop_for_unknown(self, tool):
+        """cleanup_display is a safe no-op for unknown session ids."""
+        tool.cleanup_display("nonexistent")  # should not raise
 
 
-class TestXvfbAvailability:
-    """Tests for the _xvfb_available helper."""
+# ------------------------------------------------------------------
+# Standalone helper tests
+# ------------------------------------------------------------------
+
+
+class TestPreFlightHelpers:
+    """Tests for module-level pre-flight helpers."""
 
     def test_xvfb_available_when_present(self):
-        """Returns True when xvfb-run is on PATH."""
-        with patch("openroad_mcp.tools.gui.shutil.which", return_value="/usr/bin/xvfb-run"):
+        with patch("openroad_mcp.tools.gui.shutil.which", return_value="/usr/bin/Xvfb"):
             from openroad_mcp.tools.gui import _xvfb_available
 
             assert _xvfb_available() is True
 
     def test_xvfb_available_when_absent(self):
-        """Returns False when xvfb-run is not on PATH."""
         with patch("openroad_mcp.tools.gui.shutil.which", return_value=None):
             from openroad_mcp.tools.gui import _xvfb_available
 
             assert _xvfb_available() is False
 
+    def test_import_available_when_present(self):
+        with patch("openroad_mcp.tools.gui.shutil.which", return_value="/usr/bin/import"):
+            from openroad_mcp.tools.gui import _import_available
 
-# ------------------------------------------------------------------
-# Helpers
-# ------------------------------------------------------------------
+            assert _import_available() is True
 
+    def test_import_available_when_absent(self):
+        with patch("openroad_mcp.tools.gui.shutil.which", return_value=None):
+            from openroad_mcp.tools.gui import _import_available
 
-def _side_effect_write(path: Path, result: InteractiveExecResult) -> InteractiveExecResult:
-    """Side effect that writes _MINIMAL_PNG and returns the mock result."""
-    path.write_bytes(_MINIMAL_PNG)
-    return result
+            assert _import_available() is False
+
+    def test_find_free_display_no_locks(self, tmp_path):
+        """Returns first number in range when no lock files exist."""
+        with patch("openroad_mcp.tools.gui.Path") as MockPath:
+            MockPath.return_value.exists.return_value = False
+            # _find_free_display expects /tmp/.X{N}-lock not to exist
+            num = _find_free_display()
+            assert 42 <= num < 300

--- a/tests/tools/test_gui_tool.py
+++ b/tests/tools/test_gui_tool.py
@@ -1,0 +1,487 @@
+"""Unit tests for GuiScreenshotTool implementation.
+
+Tests all code paths using mocked dependencies (no xvfb/OpenROAD required).
+Integration tests that exercise the real GUI are in tests/integration/test_gui.py.
+"""
+
+import base64
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from openroad_mcp.core.models import InteractiveExecResult
+from openroad_mcp.interactive.models import (
+    SessionError,
+    SessionNotFoundError,
+    SessionTerminatedError,
+)
+from openroad_mcp.tools.gui import (
+    DEFAULT_DISPLAY_RESOLUTION,
+    IMAGE_CAPTURE_TIMEOUT_MS,
+    MAX_SCREENSHOT_SIZE_MB,
+    GuiScreenshotTool,
+)
+
+# Minimal valid PNG (1x1 pixel, RGBA)
+_MINIMAL_PNG = (
+    b"\x89PNG\r\n\x1a\n"  # signature
+    b"\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+    b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89"
+    b"\x00\x00\x00\nIDATx\x9cc\x00\x01\x00\x00\x05\x00\x01"
+    b"\r\n\xb4\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
+
+@pytest.mark.asyncio
+class TestGuiScreenshotTool:
+    """Test suite for GuiScreenshotTool."""
+
+    @pytest.fixture
+    def mock_manager(self):
+        """Create a mock OpenROADManager."""
+        return AsyncMock()
+
+    @pytest.fixture
+    def tool(self, mock_manager) -> GuiScreenshotTool:
+        """Create GuiScreenshotTool with mock manager."""
+        return GuiScreenshotTool(mock_manager)
+
+    # ------------------------------------------------------------------
+    # Positive: successful screenshot (happy path)
+    # ------------------------------------------------------------------
+    async def test_successful_screenshot(self, tool, mock_manager, tmp_path):
+        """Full happy path: existing session → save_image → PNG returned."""
+        out_file = tmp_path / "screenshot.png"
+
+        mock_result = InteractiveExecResult(
+            output="",
+            session_id="gui-sess-1",
+            timestamp="2024-01-01T00:00:00Z",
+            execution_time=0.1,
+            command_count=1,
+        )
+
+        # Simulate gui::save_image writing the file during execute_command
+        def _write_and_return(*_args, **_kwargs):
+            out_file.write_bytes(_MINIMAL_PNG)
+            return mock_result
+
+        mock_manager.execute_command.side_effect = _write_and_return
+
+        raw = await tool.execute(session_id="gui-sess-1", output_path=str(out_file))
+        result = json.loads(raw)
+
+        assert result["error"] is None
+        assert result["session_id"] == "gui-sess-1"
+        assert result["image_format"] == "png"
+        assert result["size_bytes"] == len(_MINIMAL_PNG)
+        assert result["message"] == "Screenshot captured successfully."
+
+        # Verify base64 round-trips correctly
+        decoded = base64.b64decode(result["image_data"])
+        assert decoded == _MINIMAL_PNG
+
+    async def test_successful_screenshot_auto_session(self, tool, mock_manager, tmp_path):
+        """When no session_id is given, a new session is created via xvfb-run."""
+        out_file = tmp_path / "auto.png"
+
+        mock_manager.create_session.return_value = "auto-session"
+
+        mock_result = InteractiveExecResult(
+            output="",
+            session_id="auto-session",
+            timestamp="2024-01-01T00:00:00Z",
+            execution_time=0.2,
+            command_count=1,
+        )
+        mock_manager.execute_command.side_effect = lambda *a, **kw: _side_effect_write(out_file, mock_result)
+
+        with patch("openroad_mcp.tools.gui._xvfb_available", return_value=True):
+            with patch("asyncio.sleep", new_callable=AsyncMock):  # skip startup delay
+                raw = await tool.execute(output_path=str(out_file))
+
+        result = json.loads(raw)
+        assert result["error"] is None
+        assert result["session_id"] == "auto-session"
+
+        # Verify xvfb-run command was passed to create_session
+        call_args = mock_manager.create_session.call_args
+        # create_session is called with keyword arg 'command' (a list)
+        cmd_list = call_args.kwargs.get("command", call_args.args[0] if call_args.args else [])
+        assert "xvfb-run" in cmd_list
+        assert "-gui" in cmd_list
+
+    async def test_default_resolution_and_timeout(self, tool, mock_manager, tmp_path):
+        """Defaults for resolution and timeout are applied when not specified."""
+        out_file = tmp_path / "defaults.png"
+
+        mock_result = InteractiveExecResult(
+            output="",
+            session_id="s1",
+            timestamp="2024-01-01T00:00:00Z",
+            execution_time=0.1,
+            command_count=1,
+        )
+        mock_manager.execute_command.side_effect = lambda *a, **kw: _side_effect_write(out_file, mock_result)
+
+        raw = await tool.execute(session_id="s1", output_path=str(out_file))
+        result = json.loads(raw)
+
+        assert result["resolution"] == DEFAULT_DISPLAY_RESOLUTION
+        # execute_command should receive the default timeout
+        call_args = mock_manager.execute_command.call_args.args
+        assert call_args[2] == IMAGE_CAPTURE_TIMEOUT_MS
+
+    async def test_custom_resolution(self, tool, mock_manager, tmp_path):
+        """Custom resolution is threaded through to the result."""
+        out_file = tmp_path / "custom_res.png"
+
+        mock_result = InteractiveExecResult(
+            output="",
+            session_id="s1",
+            timestamp="2024-01-01T00:00:00Z",
+            execution_time=0.1,
+            command_count=1,
+        )
+        mock_manager.execute_command.side_effect = lambda *a, **kw: _side_effect_write(
+            out_file,
+            mock_result,
+        )
+
+        raw = await tool.execute(
+            session_id="s1",
+            resolution="1920x1080x24",
+            output_path=str(out_file),
+        )
+        result = json.loads(raw)
+
+        assert result["resolution"] == "1920x1080x24"
+
+    async def test_custom_timeout(self, tool, mock_manager, tmp_path):
+        """Custom timeout_ms is forwarded to execute_command."""
+        out_file = tmp_path / "timeout.png"
+
+        mock_result = InteractiveExecResult(
+            output="",
+            session_id="s1",
+            timestamp="2024-01-01T00:00:00Z",
+            execution_time=0.1,
+            command_count=1,
+        )
+        mock_manager.execute_command.side_effect = lambda *a, **kw: _side_effect_write(
+            out_file,
+            mock_result,
+        )
+
+        await tool.execute(session_id="s1", output_path=str(out_file), timeout_ms=20_000)
+
+        call_args = mock_manager.execute_command.call_args.args
+        assert call_args[2] == 20_000
+
+    # ------------------------------------------------------------------
+    # Positive: temp file path generation
+    # ------------------------------------------------------------------
+    async def test_temp_file_used_when_no_output_path(self, tool, mock_manager):
+        """When output_path is omitted a temp file under /tmp is used."""
+        mock_result = InteractiveExecResult(
+            output="",
+            session_id="s1",
+            timestamp="2024-01-01T00:00:00Z",
+            execution_time=0.1,
+            command_count=1,
+        )
+
+        # We need the temp file path to write the PNG into
+        written_path: list[Path] = []
+
+        async def _capture_path(sid, cmd, timeout):
+            # Extract path from the Tcl command
+            # e.g.  gui::save_image "/tmp/openroad_gui_xxxx.png"
+            path_str = cmd.split('"')[1]
+            p = Path(path_str)
+            p.write_bytes(_MINIMAL_PNG)
+            written_path.append(p)
+            return mock_result
+
+        mock_manager.execute_command.side_effect = _capture_path
+
+        raw = await tool.execute(session_id="s1")
+        result = json.loads(raw)
+
+        assert result["error"] is None
+        assert result["image_path"].startswith(tempfile.gettempdir())
+        assert result["image_path"].endswith(".png")
+
+        # Cleanup
+        if written_path:
+            written_path[0].unlink(missing_ok=True)
+
+    # ------------------------------------------------------------------
+    # Negative: xvfb not installed
+    # ------------------------------------------------------------------
+    async def test_xvfb_not_found_error(self, tool):
+        """Returns structured error when xvfb-run is missing."""
+        with patch("openroad_mcp.tools.gui._xvfb_available", return_value=False):
+            raw = await tool.execute()
+            result = json.loads(raw)
+
+        assert result["error"] == "XvfbNotFound"
+        assert "xvfb-run" in result["message"]
+
+    # ------------------------------------------------------------------
+    # Negative: screenshot file missing / empty
+    # ------------------------------------------------------------------
+    async def test_screenshot_failed_file_missing(self, tool, mock_manager, tmp_path):
+        """Returns ScreenshotFailed when gui::save_image produces no file."""
+        out_file = tmp_path / "missing.png"
+
+        mock_result = InteractiveExecResult(
+            output="some gui output",
+            session_id="s1",
+            timestamp="2024-01-01T00:00:00Z",
+            execution_time=0.1,
+            command_count=1,
+        )
+        # Don't write anything — simulate gui::save_image failure
+        mock_manager.execute_command.return_value = mock_result
+
+        with patch("openroad_mcp.tools.gui._FILE_POLL_MAX_WAIT", 0.1):  # speed up polling
+            raw = await tool.execute(session_id="s1", output_path=str(out_file))
+
+        result = json.loads(raw)
+
+        assert result["error"] == "ScreenshotFailed"
+        assert "not created" in result["message"] or "empty" in result["message"]
+        assert result["session_id"] == "s1"
+
+    async def test_screenshot_failed_file_empty(self, tool, mock_manager, tmp_path):
+        """Returns ScreenshotFailed when gui::save_image writes a 0-byte file."""
+        out_file = tmp_path / "empty.png"
+
+        mock_result = InteractiveExecResult(
+            output="gui output",
+            session_id="s1",
+            timestamp="2024-01-01T00:00:00Z",
+            execution_time=0.1,
+            command_count=1,
+        )
+        mock_manager.execute_command.return_value = mock_result
+
+        # Write a zero-byte file — simulates partial write
+        out_file.write_bytes(b"")
+
+        with patch("openroad_mcp.tools.gui._FILE_POLL_MAX_WAIT", 0.1):
+            raw = await tool.execute(session_id="s1", output_path=str(out_file))
+
+        result = json.loads(raw)
+
+        assert result["error"] == "ScreenshotFailed"
+        assert result["session_id"] == "s1"
+
+    # ------------------------------------------------------------------
+    # Negative: file too large
+    # ------------------------------------------------------------------
+    async def test_file_too_large_error(self, tool, mock_manager, tmp_path):
+        """Returns FileTooLarge when screenshot exceeds MAX_SCREENSHOT_SIZE_MB."""
+        out_file = tmp_path / "huge.png"
+
+        # Create a file that exceeds the size limit.
+        # The side_effect writes a huge file *during* execute_command,
+        # so it exists when the polling loop checks.
+        huge_size = (MAX_SCREENSHOT_SIZE_MB + 1) * 1024 * 1024
+
+        mock_result = InteractiveExecResult(
+            output="",
+            session_id="s1",
+            timestamp="2024-01-01T00:00:00Z",
+            execution_time=0.1,
+            command_count=1,
+        )
+
+        def _write_huge(*_a, **_kw):
+            out_file.write_bytes(b"\x00" * huge_size)
+            return mock_result
+
+        mock_manager.execute_command.side_effect = _write_huge
+
+        raw = await tool.execute(session_id="s1", output_path=str(out_file))
+        result = json.loads(raw)
+
+        assert result["error"] == "FileTooLarge"
+        assert str(MAX_SCREENSHOT_SIZE_MB) in result["message"]
+
+    # ------------------------------------------------------------------
+    # Negative: session not found
+    # ------------------------------------------------------------------
+    async def test_session_not_found_error(self, tool, mock_manager):
+        """Returns SessionNotFound for non-existent session_id."""
+        mock_manager.execute_command.side_effect = SessionNotFoundError("not found")
+
+        raw = await tool.execute(session_id="ghost-session")
+        result = json.loads(raw)
+
+        assert result["error"] == "SessionNotFound"
+        assert result["session_id"] == "ghost-session"
+        assert "not found" in result["message"]
+
+    # ------------------------------------------------------------------
+    # Negative: session terminated
+    # ------------------------------------------------------------------
+    async def test_session_terminated_error(self, tool, mock_manager):
+        """Returns SessionError when session has terminated."""
+        mock_manager.execute_command.side_effect = SessionTerminatedError("session has been terminated")
+
+        raw = await tool.execute(session_id="dead-session")
+        result = json.loads(raw)
+
+        assert result["error"] == "SessionError"
+        assert result["session_id"] == "dead-session"
+
+    async def test_session_error(self, tool, mock_manager):
+        """Returns SessionError for generic session errors."""
+        mock_manager.execute_command.side_effect = SessionError("something went wrong")
+
+        raw = await tool.execute(session_id="bad-session")
+        result = json.loads(raw)
+
+        assert result["error"] == "SessionError"
+        assert "something went wrong" in result["message"]
+
+    # ------------------------------------------------------------------
+    # Negative: unexpected exception
+    # ------------------------------------------------------------------
+    async def test_unexpected_error(self, tool, mock_manager):
+        """Returns UnexpectedError for unhandled exceptions."""
+        mock_manager.execute_command.side_effect = RuntimeError("kaboom")
+
+        raw = await tool.execute(session_id="s1")
+        result = json.loads(raw)
+
+        assert result["error"] == "UnexpectedError"
+        assert "kaboom" in result["message"]
+
+    # ------------------------------------------------------------------
+    # Edge: stale file is cleaned before screenshot
+    # ------------------------------------------------------------------
+    async def test_stale_file_removed_before_capture(self, tool, mock_manager, tmp_path):
+        """A stale file at the output path is removed before gui::save_image."""
+        out_file = tmp_path / "stale.png"
+        out_file.write_bytes(b"old data")
+
+        mock_result = InteractiveExecResult(
+            output="",
+            session_id="s1",
+            timestamp="2024-01-01T00:00:00Z",
+            execution_time=0.1,
+            command_count=1,
+        )
+        mock_manager.execute_command.side_effect = lambda *a, **kw: _side_effect_write(
+            out_file,
+            mock_result,
+        )
+
+        raw = await tool.execute(session_id="s1", output_path=str(out_file))
+        result = json.loads(raw)
+
+        assert result["error"] is None
+        # The image_data should be _MINIMAL_PNG, not "old data"
+        decoded = base64.b64decode(result["image_data"])
+        assert decoded == _MINIMAL_PNG
+
+    # ------------------------------------------------------------------
+    # Edge: polling discovers file on a later iteration
+    # ------------------------------------------------------------------
+    async def test_polling_waits_for_file(self, tool, mock_manager, tmp_path):
+        """File appears after a delay — polling loop picks it up."""
+        import asyncio
+
+        out_file = tmp_path / "delayed.png"
+
+        mock_result = InteractiveExecResult(
+            output="",
+            session_id="s1",
+            timestamp="2024-01-01T00:00:00Z",
+            execution_time=0.1,
+            command_count=1,
+        )
+        mock_manager.execute_command.return_value = mock_result
+
+        # Schedule the file to appear after 0.3s
+        async def _delayed_write():
+            await asyncio.sleep(0.3)
+            out_file.write_bytes(_MINIMAL_PNG)
+
+        asyncio.create_task(_delayed_write())
+
+        raw = await tool.execute(session_id="s1", output_path=str(out_file))
+        result = json.loads(raw)
+
+        assert result["error"] is None
+        assert result["size_bytes"] == len(_MINIMAL_PNG)
+
+    # ------------------------------------------------------------------
+    # Result structure: all expected fields present
+    # ------------------------------------------------------------------
+    async def test_result_contains_all_fields(self, tool, mock_manager, tmp_path):
+        """Successful result includes every GuiScreenshotResult field."""
+        out_file = tmp_path / "fields.png"
+
+        mock_result = InteractiveExecResult(
+            output="",
+            session_id="s1",
+            timestamp="2024-01-01T00:00:00Z",
+            execution_time=0.1,
+            command_count=1,
+        )
+        mock_manager.execute_command.side_effect = lambda *a, **kw: _side_effect_write(
+            out_file,
+            mock_result,
+        )
+
+        raw = await tool.execute(session_id="s1", output_path=str(out_file))
+        result = json.loads(raw)
+
+        expected_keys = {
+            "session_id",
+            "image_data",
+            "image_path",
+            "image_format",
+            "size_bytes",
+            "resolution",
+            "timestamp",
+            "message",
+            "error",
+        }
+        assert expected_keys.issubset(result.keys()), f"Missing keys: {expected_keys - result.keys()}"
+
+
+class TestXvfbAvailability:
+    """Tests for the _xvfb_available helper."""
+
+    def test_xvfb_available_when_present(self):
+        """Returns True when xvfb-run is on PATH."""
+        with patch("openroad_mcp.tools.gui.shutil.which", return_value="/usr/bin/xvfb-run"):
+            from openroad_mcp.tools.gui import _xvfb_available
+
+            assert _xvfb_available() is True
+
+    def test_xvfb_available_when_absent(self):
+        """Returns False when xvfb-run is not on PATH."""
+        with patch("openroad_mcp.tools.gui.shutil.which", return_value=None):
+            from openroad_mcp.tools.gui import _xvfb_available
+
+            assert _xvfb_available() is False
+
+
+# ------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------
+
+
+def _side_effect_write(path: Path, result: InteractiveExecResult) -> InteractiveExecResult:
+    """Side effect that writes _MINIMAL_PNG and returns the mock result."""
+    path.write_bytes(_MINIMAL_PNG)
+    return result

--- a/tests/tools/test_gui_tool.py
+++ b/tests/tools/test_gui_tool.py
@@ -1139,6 +1139,91 @@ class TestGuiScreenshotTool:
         assert result["image_data"] is None
         assert result["image_path"] is not None
 
+    # ------------------------------------------------------------------
+    # output_path as existing directory
+    # ------------------------------------------------------------------
+    async def test_output_path_existing_directory_generates_file_inside(self, tool, tmp_path):
+        """When output_path is an existing directory, generate a default filename inside it."""
+        out_dir = tmp_path / "screenshots"
+        out_dir.mkdir()
+        self._register_display(tool, "s1")
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_make_import_side_effect()):
+            raw = await tool.execute(session_id="s1", output_path=str(out_dir))
+
+        result = json.loads(raw)
+        assert result["error"] is None
+        # The image should be inside the directory, not at the directory path itself
+        final = Path(result["image_path"])
+        assert final.parent == out_dir
+        assert final.name.startswith("openroad_gui_")
+        assert final.exists()
+
+    async def test_output_path_trailing_slash_treated_as_directory(self, tool, tmp_path):
+        """output_path ending with '/' should be treated as a directory."""
+        out_dir = tmp_path / "output"
+        self._register_display(tool, "s1")
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_make_import_side_effect()):
+            raw = await tool.execute(session_id="s1", output_path=str(out_dir) + "/")
+
+        result = json.loads(raw)
+        assert result["error"] is None
+        final = Path(result["image_path"])
+        assert final.parent == out_dir
+        assert final.name.startswith("openroad_gui_")
+        assert final.exists()
+
+    async def test_output_path_directory_respects_format(self, tool, tmp_path):
+        """Directory output_path should generate file with correct format extension."""
+        out_dir = tmp_path / "pngs"
+        out_dir.mkdir()
+        self._register_display(tool, "s1")
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_make_import_side_effect()):
+            raw = await tool.execute(session_id="s1", output_path=str(out_dir), image_format="png")
+
+        result = json.loads(raw)
+        assert result["error"] is None
+        final = Path(result["image_path"])
+        assert final.suffix == ".png"
+
+    # ------------------------------------------------------------------
+    # Numeric params: empty/None resets to default
+    # ------------------------------------------------------------------
+    async def test_scale_none_resets_to_default(self, tool, tmp_path):
+        """scale=None should reset to 1.0 (no scaling), not retain previous value."""
+        out = tmp_path / "shot.jpg"
+        self._register_display(tool, "s1")
+        big_png = _create_test_png(100, 80)
+
+        # First call with scale=0.5
+        with patch("asyncio.create_subprocess_exec", side_effect=_make_import_side_effect(png_data=big_png)):
+            raw1 = await tool.execute(session_id="s1", output_path=str(out), scale=0.5)
+        r1 = json.loads(raw1)
+        assert r1["error"] is None
+        assert r1["width"] == 50
+
+        # Second call without scale (None → default 1.0)
+        out2 = tmp_path / "shot2.jpg"
+        with patch("asyncio.create_subprocess_exec", side_effect=_make_import_side_effect(png_data=big_png)):
+            raw2 = await tool.execute(session_id="s1", output_path=str(out2), scale=None)
+        r2 = json.loads(raw2)
+        assert r2["error"] is None
+        # Full-size image should be original dimensions
+        assert r2["width"] == 100
+
+    async def test_quality_none_uses_default(self, tool, tmp_path):
+        """quality=None should use the default quality setting."""
+        out = tmp_path / "shot.jpg"
+        self._register_display(tool, "s1")
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_make_import_side_effect()):
+            raw = await tool.execute(session_id="s1", output_path=str(out), quality=None)
+
+        result = json.loads(raw)
+        assert result["error"] is None
+
 
 # ------------------------------------------------------------------
 # Standalone helper tests

--- a/tests/tools/test_gui_tool.py
+++ b/tests/tools/test_gui_tool.py
@@ -122,7 +122,7 @@ class TestGuiScreenshotTool:
 
         with (
             patch("openroad_mcp.tools.gui._xvfb_available", return_value=True),
-            patch("openroad_mcp.tools.gui._openroad_available", return_value=True),
+            patch("openroad_mcp.tools.gui._get_openroad_exe", return_value="/usr/bin/openroad"),
             patch("openroad_mcp.tools.gui._import_available", return_value=True),
             patch("asyncio.create_subprocess_exec", side_effect=_create_sub),
             patch("asyncio.sleep", new_callable=AsyncMock),
@@ -133,10 +133,10 @@ class TestGuiScreenshotTool:
         assert result["error"] is None
         assert result["session_id"] == "auto-sess"
 
-        # Verify create_session used openroad -gui (not xvfb-run)
+        # Verify create_session used the resolved openroad path
         call_kw = mock_manager.create_session.call_args.kwargs
         cmd = call_kw.get("command", [])
-        assert cmd == ["openroad", "-gui", "-no_init"]
+        assert cmd == ["/usr/bin/openroad", "-gui", "-no_init"]
         assert "DISPLAY" in call_kw.get("env", {})
 
     # ------------------------------------------------------------------
@@ -173,7 +173,7 @@ class TestGuiScreenshotTool:
 
         with (
             patch("openroad_mcp.tools.gui._xvfb_available", return_value=True),
-            patch("openroad_mcp.tools.gui._openroad_available", return_value=True),
+            patch("openroad_mcp.tools.gui._get_openroad_exe", return_value="/usr/bin/openroad"),
             patch("openroad_mcp.tools.gui._import_available", return_value=True),
             patch("asyncio.create_subprocess_exec", side_effect=_create_sub),
             patch("asyncio.sleep", new_callable=AsyncMock),
@@ -242,7 +242,7 @@ class TestGuiScreenshotTool:
         """Returns structured error when openroad is missing."""
         with (
             patch("openroad_mcp.tools.gui._xvfb_available", return_value=True),
-            patch("openroad_mcp.tools.gui._openroad_available", return_value=False),
+            patch("openroad_mcp.tools.gui._get_openroad_exe", return_value=None),
         ):
             raw = await tool.execute()
         result = json.loads(raw)
@@ -253,7 +253,7 @@ class TestGuiScreenshotTool:
         """Returns structured error when ImageMagick import is missing."""
         with (
             patch("openroad_mcp.tools.gui._xvfb_available", return_value=True),
-            patch("openroad_mcp.tools.gui._openroad_available", return_value=True),
+            patch("openroad_mcp.tools.gui._get_openroad_exe", return_value="/usr/bin/openroad"),
             patch("openroad_mcp.tools.gui._import_available", return_value=False),
         ):
             raw = await tool.execute()
@@ -362,7 +362,7 @@ class TestGuiScreenshotTool:
 
         with (
             patch("openroad_mcp.tools.gui._xvfb_available", return_value=True),
-            patch("openroad_mcp.tools.gui._openroad_available", return_value=True),
+            patch("openroad_mcp.tools.gui._get_openroad_exe", return_value="/usr/bin/openroad"),
             patch("openroad_mcp.tools.gui._import_available", return_value=True),
             patch("asyncio.create_subprocess_exec", return_value=_make_xvfb_proc()),
             patch("asyncio.sleep", new_callable=AsyncMock),
@@ -441,7 +441,7 @@ class TestGuiScreenshotTool:
 
         with (
             patch("openroad_mcp.tools.gui._xvfb_available", return_value=True),
-            patch("openroad_mcp.tools.gui._openroad_available", return_value=True),
+            patch("openroad_mcp.tools.gui._get_openroad_exe", return_value="/usr/bin/openroad"),
             patch("openroad_mcp.tools.gui._import_available", return_value=True),
             patch("asyncio.create_subprocess_exec", return_value=xvfb_proc),
             patch("asyncio.sleep", new_callable=AsyncMock),
@@ -510,3 +510,38 @@ class TestPreFlightHelpers:
             # _find_free_display expects /tmp/.X{N}-lock not to exist
             num = _find_free_display()
             assert 42 <= num < 300
+
+    def test_get_openroad_exe_from_env(self, tmp_path):
+        """OPENROAD_EXE env var is preferred over PATH lookup."""
+        fake_bin = tmp_path / "openroad"
+        fake_bin.write_text("#!/bin/sh\n")
+        fake_bin.chmod(0o755)
+
+        from openroad_mcp.tools.gui import _get_openroad_exe
+
+        with patch.dict("os.environ", {"OPENROAD_EXE": str(fake_bin)}):
+            result = _get_openroad_exe()
+        assert result == str(fake_bin.resolve())
+
+    def test_get_openroad_exe_falls_back_to_which(self):
+        """Falls back to shutil.which when OPENROAD_EXE is not set."""
+        from openroad_mcp.tools.gui import _get_openroad_exe
+
+        with (
+            patch.dict("os.environ", {}, clear=False),
+            patch("openroad_mcp.tools.gui.os.environ.get", return_value=None),
+            patch("openroad_mcp.tools.gui.shutil.which", return_value="/usr/bin/openroad"),
+        ):
+            result = _get_openroad_exe()
+        assert result == "/usr/bin/openroad"
+
+    def test_get_openroad_exe_returns_none(self):
+        """Returns None when openroad is not found anywhere."""
+        from openroad_mcp.tools.gui import _get_openroad_exe
+
+        with (
+            patch.dict("os.environ", {"OPENROAD_EXE": "/nonexistent/openroad"}),
+            patch("openroad_mcp.tools.gui.shutil.which", return_value=None),
+        ):
+            result = _get_openroad_exe()
+        assert result is None


### PR DESCRIPTION
## Summary

Add a `gui_screenshot` MCP tool that captures screenshots from OpenROAD's GUI running in a headless X11 display. OpenROAD in `-gui` mode does not accept Tcl commands via stdin/PTY, so this tool uses Xvfb + ImageMagick `import -window root` to capture the framebuffer directly.

Fixes #16

## What's New

### Core Feature
- **Headless GUI lifecycle**: Automatically starts Xvfb → launches `openroad -gui -no_init` → waits for display + window readiness → captures screenshot
- **Image post-processing via Pillow**: Crop (pixel coordinates), scale (0.0–1.0], format conversion (PNG/JPEG/WebP)
- **Three return modes** for token efficiency:
  - `base64` — full image as base-64 (default)
  - `path` — file path only, no image data
  - `preview` — 256px thumbnail + file path

### Token Optimization
JPEG default with quality=85 reduces screenshot payloads by **70–90%** compared to raw PNG base64. The `path` and `preview` return modes save even more by avoiding large base64 payloads entirely.

### Configuration
All tunable values are centralized in `Settings` with environment variable overrides (`OPENROAD_GUI_*` prefix):

| Setting | Default | Env Var |
|---------|---------|---------|
| `GUI_DEFAULT_IMAGE_FORMAT` | `jpeg` | `OPENROAD_GUI_DEFAULT_IMAGE_FORMAT` |
| `GUI_DEFAULT_JPEG_QUALITY` | `85` | `OPENROAD_GUI_DEFAULT_JPEG_QUALITY` |
| `GUI_CAPTURE_TIMEOUT_MS` | `8000` | `OPENROAD_GUI_CAPTURE_TIMEOUT_MS` |
| `GUI_DISPLAY_RESOLUTION` | `1280x1024x24` | `OPENROAD_GUI_DISPLAY_RESOLUTION` |
| `GUI_PREVIEW_SIZE_PX` | `256` | `OPENROAD_GUI_PREVIEW_SIZE_PX` |
| `GUI_MAX_SCREENSHOT_SIZE_MB` | `10` | `OPENROAD_GUI_MAX_SCREENSHOT_SIZE_MB` |
| + 10 more startup/timing/cleanup settings | | |

### MCP Inspector Compatibility
All tool parameters use `str = ""` (not `str | None` or `int | None`) to avoid the MCP Inspector `anyOf` type-toggle bug where clearing a field retains the previous value instead of resetting to default. Empty strings are parsed and normalized before reaching the tool logic.

### Smart `output_path` Handling
- Directory paths generate a default filename inside the directory
- Format inferred from file extension when `image_format` is omitted
- Parent directories created automatically
- Extension auto-corrected to match chosen format

## Files Changed (10 files, +2585 lines)

| File | Change |
|------|--------|
| `src/openroad_mcp/tools/gui.py` | New — core screenshot tool (756 lines) |
| `tests/tools/test_gui_tool.py` | New — 79 unit tests (1467 lines) |
| `tests/integration/test_gui.py` | New — Docker integration tests |
| `src/openroad_mcp/server.py` | Register `gui_screenshot` MCP tool |
| `src/openroad_mcp/config/settings.py` | 16 new GUI settings with env var overrides |
| `src/openroad_mcp/core/models.py` | `GuiScreenshotResult` data model |
| `src/openroad_mcp/tools/__init__.py` | Export `GuiScreenshotTool` |
| `src/openroad_mcp/tools/base.py` | Add `_format_result` helper |
| `Dockerfile.test` | Add Xvfb, ImageMagick, x11-utils |
| `README.md` | Document GUI screenshot tool |

## Test Results

- **79 GUI-specific tests**: capture flow, crop, scale, format conversion, return modes, error handling, parameter normalization, directory output, MCP Inspector compatibility
- **15 skipped**: integration tests requiring real Xvfb + OpenROAD (run in Docker CI)
- All pre-commit hooks pass (ruff lint + format, trailing whitespace)

## Prerequisites

- Xvfb (`apt-get install -y xvfb`)
- ImageMagick (`apt-get install -y imagemagick`)
- Pillow >= 12.0.0 (added to dependencies)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a gui_screenshot tool and API endpoint for headless GUI captures with session reuse, configurable resolution/format/quality/scale/crop, and multiple return modes (base64/path/preview).

* **User-facing Data**
  * Results now include rich capture metadata (sizes, resolution, timestamps, compression, session id, messages).

* **Documentation**
  * Documented headless GUI support, usage, return modes, formats, and prerequisites.

* **Tests**
  * Added comprehensive unit and integration tests for happy paths, errors, sessions, and parameter validation.

* **Chores**
  * Test image updated with headless GUI testing dependencies; shutdown now cleans GUI sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->