### PR TITLE
Feat add token efficiency benchmarks for mcp responses

### DIFF
--- a/src/openroad_mcp/tools/base.py
+++ b/src/openroad_mcp/tools/base.py
@@ -55,5 +55,5 @@ class BaseTool(ABC):
     ) -> str:
         """Format result as JSON string."""
         if hasattr(result, "model_dump"):
-            return json.dumps(result.model_dump(), indent=2)
-        return json.dumps(result, indent=2)
+            return json.dumps(result.model_dump(), separators=(",", ":"))
+        return json.dumps(result, separators=(",", ":"))

--- a/src/openroad_mcp/tools/interactive.py
+++ b/src/openroad_mcp/tools/interactive.py
@@ -30,7 +30,7 @@ def _blocked_error(command: str, blocked_verb: str, session_id: str | None) -> s
         execution_time=0.0,
         error=f"CommandBlocked: '{blocked_verb}'",
     )
-    return json.dumps(result.model_dump(), indent=2, default=str)
+    return json.dumps(result.model_dump(), separators=(",", ":"), default=str)
 
 
 class QueryShellTool(BaseTool):

--- a/tests/performance/test_response_sizes.py
+++ b/tests/performance/test_response_sizes.py
@@ -149,6 +149,7 @@ class TestLiveToolCompactness:
     its own serialize/execute method, which static model tests miss.
     """
 
+    @pytest.mark.asyncio
     async def test_list_sessions_tool_output_is_compact(self) -> None:
         """ListSessionsTool.execute() must return compact JSON."""
         manager = MagicMock()
@@ -254,16 +255,19 @@ class TestTokenCostReport:
         exec_typical = results[1]
         session_empty = results[2]
 
-        assert exec_minimal["estimated_tokens"] == token_estimate(exec_minimal["compact_json"]), (
-            "ExecResult(minimal) token count mismatch"
+        # Assert token math against pinned expected values.
+        # If these fail, a model field was added/removed or serializer changed.
+        assert exec_minimal["estimated_tokens"] == 34, (
+            f"ExecResult(minimal) token count changed to {exec_minimal['estimated_tokens']} "
+            "(was 34) — model fields may have changed"
         )
-
-        assert exec_typical["estimated_tokens"] == token_estimate(exec_typical["compact_json"]), (
-            "ExecResult(typical) token count mismatch"
+        assert exec_typical["estimated_tokens"] == 41, (
+            f"ExecResult(typical) token count changed to {exec_typical['estimated_tokens']} "
+            "(was 41) — model fields may have changed"
         )
-
-        assert session_empty["estimated_tokens"] == token_estimate(session_empty["compact_json"]), (
-            "SessionList(empty) token count mismatch"
+        assert session_empty["estimated_tokens"] == 15, (
+            f"SessionList(empty) token count changed to {session_empty['estimated_tokens']} "
+            "(was 15) — model fields may have changed"
         )
 
         # Assert savings are positive (compact is always smaller than pretty)


### PR DESCRIPTION
Addresses issue #42 question 1: 'Are we following best practices
for compact JSON representation?'

- Verifies all response types use compact JSON separators (no indent=2)
- Asserts token budgets with documented justification:
  ExecResult <80 tokens, empty SessionList <30 tokens
- Tests live tool output via ListSessionsTool (not just static models)
- Prints token cost table in CI logs for visibility

Note: Latency benchmarks (question 2) require a running OpenROAD
process and will follow once Docker deployment (#28) is merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched JSON output to a compact format (no extra whitespace), reducing response size and lowering token usage for relevant responses.

* **Tests**
  * Added a performance test suite that measures token efficiency, validates compact JSON output (including absence of whitespace), verifies tool outputs remain compact, and produces token-cost reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->