### PR TITLE
fix: replace cleanup() with cleanup_all() in test_session_manager

### DIFF
--- a/tests/interactive/test_session_manager.py
+++ b/tests/interactive/test_session_manager.py
@@ -458,4 +458,4 @@ class TestSessionManagerAsync:
             assert manager.get_session_count() == num_sessions - sessions_to_cleanup
 
         finally:
-            await manager.cleanup()
+            await manager.cleanup_all()


### PR DESCRIPTION
Fixes luarss/openroad-mcp#72

`OpenROADManager` defines `cleanup_all()` but two tests called the
nonexistent `cleanup()`, causing `AttributeError` at teardown.

- `test_cleanup_all_sessions` (line 242)
- `test_concurrent_session_creation` (line 422)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated async test cleanup to use the correct cleanup method across lifecycle and stress test flows, ensuring sessions are fully cleared and tests reliably reset state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->