### PR TITLE
fix: add --init to all docker run targets to prevent zombie process accumulation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,12 +50,12 @@ build:
 .PHONY: test-interactive
 test-interactive: docker-test-build
 	@echo "Running interactive tests..."
-	@docker run --rm $(DOCKER_TEST_IMAGE) uv run pytest tests/interactive
+	@docker run --rm --init $(DOCKER_TEST_IMAGE) uv run pytest tests/interactive
 
 .PHONY: test-integration
 test-integration: docker-test-build
 	@echo "Running integration tests for timing workflows..."
-	@docker run --rm $(DOCKER_TEST_IMAGE) uv run pytest tests/integration
+	@docker run --rm --init $(DOCKER_TEST_IMAGE) uv run pytest tests/integration
 
 .PHONY: test-tools
 test-tools:
@@ -65,12 +65,12 @@ test-tools:
 .PHONY: test-performance
 test-performance: docker-test-build
 	@echo "Running performance tests (benchmarks, memory, stability)..."
-	@docker run --rm $(DOCKER_TEST_IMAGE) uv run pytest tests/performance/
+	@docker run --rm --init $(DOCKER_TEST_IMAGE) uv run pytest tests/performance/
 
 .PHONY: test-coverage
 test-coverage: docker-test-build
 	@echo "Running tests with coverage analysis..."
-	@docker run --rm -v $(PWD):/output $(DOCKER_TEST_IMAGE) sh -c "\
+	@docker run --rm --init -v $(PWD):/output $(DOCKER_TEST_IMAGE) sh -c "\
 		uv run pytest --ignore=tests/performance \
 			--cov=src/openroad_mcp \
 			--cov-report=xml \


### PR DESCRIPTION
## Summary

- Added `--init` flag to all four `docker run` invocations in the Makefile 
  (`test-interactive`, `test-integration`, `test-performance`, `test-coverage`)
- Prevents zombie process accumulation when PTY subprocesses (OpenROAD sessions) 
  exit and PID 1 fails to reap them
- Particularly relevant under repeated subprocess spawning in integration and 
  performance test scenarios

Fixes #78

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Docker container configuration for test execution to enhance process management and signal handling within test environments, ensuring more stable and reliable test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->