### PR TITLE
feat: add MCP registry publishing to release pipeline

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,7 +7,6 @@ on:
         description: Docker image tag to publish (e.g. v0.1.0)
         required: true
         type: string
-
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
@@ -31,8 +30,12 @@ jobs:
       - name: Build Docker image
         run: make build
 
-      - name: Push Docker image
+      - name: Tag and push Docker image
         run: |
           ORFS_VER=$(make --no-print-directory print-ORFS_VERSION)
-          docker tag ghcr.io/luarss/openroad-mcp:$ORFS_VER ghcr.io/luarss/openroad-mcp:"$IMAGE_TAG"
-          docker push ghcr.io/luarss/openroad-mcp:"$IMAGE_TAG"
+          IMAGE=ghcr.io/luarss/openroad-mcp
+          docker tag $IMAGE:$ORFS_VER $IMAGE:"$IMAGE_TAG"
+          docker tag $IMAGE:$ORFS_VER $IMAGE:latest
+          docker push $IMAGE:$ORFS_VER
+          docker push $IMAGE:"$IMAGE_TAG"
+          docker push $IMAGE:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,3 +101,23 @@ jobs:
     with:
       image_tag: ${{ github.ref_name }}
     secrets: inherit
+
+  publish-mcp-registry:
+    name: Publish to MCP Registry
+    needs: [publish-pypi, publish-docker]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,8 @@ WORKDIR /app
 COPY --from=builder --chown=appuser:appuser /app/.venv /app/.venv
 COPY --from=builder --chown=appuser:appuser /opt/python /opt/python
 
+LABEL io.modelcontextprotocol.server.name="io.github.luarss/openroad-mcp"
+
 USER appuser
 
 ENV PATH="/app/.venv/bin:/OpenROAD-flow-scripts/tools/install/OpenROAD/bin:/OpenROAD-flow-scripts/tools/install/yosys/bin:$PATH" \

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # OpenROAD MCP Server
 
+<!-- mcp-name: io.github.luarss/openroad-mcp -->
+
 A Model Context Protocol (MCP) server that provides tools for interacting with OpenROAD and ORFS (OpenROAD Flow Scripts).
 
 ## Demo
@@ -101,6 +103,17 @@ Follow the [Gemini MCP install guide](https://ai.google.dev/gemini-api/docs/mode
 <summary><b>Docker</b></summary>
 
 🚧 **Work in Progress**: Docker deployment via GitHub Container Registry (GHCR) is coming soon.
+
+</details>
+
+<details>
+<summary><b>MCP Registry</b></summary>
+
+Once published to the [MCP Registry](https://registry.modelcontextprotocol.io), clients can discover and install directly:
+
+```bash
+uvx openroad-mcp
+```
 
 </details>
 

--- a/server.json
+++ b/server.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.luarss/openroad-mcp",
+  "description": "The OpenROAD MCP server - interactive EDA sessions via Model Context Protocol",
+  "repository": {
+    "url": "https://github.com/luarss/openroad-mcp",
+    "source": "github"
+  },
+  "version": "0.3.0",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "openroad-mcp",
+      "version": "0.3.0",
+      "transport": { "type": "stdio" },
+      "runtimeHint": "uvx"
+    },
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/luarss/openroad-mcp:0.3.0",
+      "transport": { "type": "stdio" },
+      "runtimeHint": "docker"
+    }
+  ]
+}


### PR DESCRIPTION
- Add server.json manifest for MCP server registry
- Add publish-mcp-registry job with jq-based version bumping
- Add Docker latest tag push alongside version tag
- Add empty changelog guard for GitHub releases
- Add mcp-name marker and registry section to README
- Add MCP server name LABEL to Dockerfile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server registered in the MCP Registry for discovery/installation.
  * Docker image publishes an additional "latest" tag.
  * Automated MCP Registry publishing workflow added for releases.

* **Documentation**
  * Added MCP Registry installation/discovery instructions enabling direct install via client tooling.

* **Release**
  * Improved release workflow handling for empty changelogs and prerelease tagging.
  * Package version advanced to 0.3.0.dev4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->