### PR TITLE
chore(deps): pin all direct dependencies to exact versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,11 +12,11 @@ description = "The OpenROAD MCP server"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "fastmcp>=2.10.6",
-    "mcp[cli]>=1.12.1",
-    "pillow>=12.0.0",
-    "psutil>=7.1.0",
-    "pydantic>=2.11.7",
+    "fastmcp==3.2.0",
+    "mcp[cli]==1.26.0",
+    "pillow==12.2.0",
+    "psutil==7.2.2",
+    "pydantic==2.12.5",
 ]
 
 [project.scripts]
@@ -24,14 +24,14 @@ openroad-mcp = "openroad_mcp.main:main"
 
 [project.optional-dependencies]
 dev = [
-    "google-genai>=1.53.0",
-    "mypy>=1.17.0",
-    "pre-commit>=4.2.0",
-    "pytest>=8.4.1",
-    "pytest-asyncio>=1.1.0",
-    "pytest-cov>=7.0.0",
-    "ruff>=0.12.5",
-    "types-psutil>=7.0.0.20250822",
+    "google-genai==1.69.0",
+    "mypy==1.20.0",
+    "pre-commit==4.5.1",
+    "pytest==9.0.3",
+    "pytest-asyncio==1.3.0",
+    "pytest-cov==7.1.0",
+    "ruff==0.15.8",
+    "types-psutil==7.2.2.20260130",
 ]
 
 [tool.mypy]

--- a/uv.lock
+++ b/uv.lock
@@ -919,19 +919,19 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastmcp", specifier = ">=2.10.6" },
-    { name = "google-genai", marker = "extra == 'dev'", specifier = ">=1.53.0" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.12.1" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.17.0" },
-    { name = "pillow", specifier = ">=12.0.0" },
-    { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.2.0" },
-    { name = "psutil", specifier = ">=7.1.0" },
-    { name = "pydantic", specifier = ">=2.11.7" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.1" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.1.0" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.0.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.5" },
-    { name = "types-psutil", marker = "extra == 'dev'", specifier = ">=7.0.0.20250822" },
+    { name = "fastmcp", specifier = "==3.2.0" },
+    { name = "google-genai", marker = "extra == 'dev'", specifier = "==1.69.0" },
+    { name = "mcp", extras = ["cli"], specifier = "==1.26.0" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==1.20.0" },
+    { name = "pillow", specifier = "==12.2.0" },
+    { name = "pre-commit", marker = "extra == 'dev'", specifier = "==4.5.1" },
+    { name = "psutil", specifier = "==7.2.2" },
+    { name = "pydantic", specifier = "==2.12.5" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = "==9.0.3" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = "==1.3.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = "==7.1.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.8" },
+    { name = "types-psutil", marker = "extra == 'dev'", specifier = "==7.2.2.20260130" },
 ]
 provides-extras = ["dev"]
 


### PR DESCRIPTION
## Summary
- Switches all `>=` lower-bound constraints in `pyproject.toml` to `==` exact pins, matching the versions currently resolved in `uv.lock`
- Updates `uv.lock` metadata section to reflect the new specifiers
- Verified with `uv sync --all-extras` — resolves cleanly with no conflicts
- fixes #112 

## Test plan
- [x] `uv sync --all-extras` completes without errors
- [x] `make test` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependencies to use exact pinned versions instead of minimum-version ranges for both runtime and development environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luarss/openroad-mcp/pull/113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->