### PR TITLE
chore: migrate all luarss refs to The-OpenROAD-Project org

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Tag and push Docker image
         run: |
           ORFS_VER=$(make --no-print-directory print-ORFS_VERSION)
-          IMAGE=ghcr.io/luarss/openroad-mcp
+          IMAGE=ghcr.io/the-openroad-project/openroad-mcp
           SEMVER="${IMAGE_TAG#v}"
           docker tag $IMAGE:$ORFS_VER $IMAGE:"$IMAGE_TAG"
           docker tag $IMAGE:$ORFS_VER $IMAGE:"$SEMVER"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,7 @@ jobs:
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/g" server.json
-          sed -i "s|ghcr.io/luarss/openroad-mcp:[^\"]*|ghcr.io/luarss/openroad-mcp:$VERSION|g" server.json
+          sed -i "s|ghcr.io/the-openroad-project/openroad-mcp:[^\"]*|ghcr.io/the-openroad-project/openroad-mcp:$VERSION|g" server.json
 
       - name: Install mcp-publisher
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Expanded coding agent documentation: added Goose, Cody, Codex CLI, PearAI, CodeBuddy, Hermes Agent, GitHub Copilot CLI, Oh My Pi, OpenClaw, AstrBot, DeepCode, nanobot, Crush, and Reasonix to README
-- Added cross-platform CI validation ([#89](https://github.com/luarss/openroad-mcp/pull/89))
+- Added cross-platform CI validation ([#89](https://github.com/The-OpenROAD-Project/openroad-mcp/pull/89))
 - Pinned GitHub Actions to full commit SHAs for supply chain safety
 - Removed editor MCP manifest files from repository
-- Bumped starlette ([#117](https://github.com/luarss/openroad-mcp/pull/117)) and idna ([#115](https://github.com/luarss/openroad-mcp/pull/115)) dependencies
+- Bumped starlette ([#117](https://github.com/The-OpenROAD-Project/openroad-mcp/pull/117)) and idna ([#115](https://github.com/The-OpenROAD-Project/openroad-mcp/pull/115)) dependencies
 
 ## [0.5.2] - 2026-05-17
 
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.0] - 2026-05-17
 
 ### Added
-- MCP integrations for Claude Desktop, Cursor, and GitHub Copilot ([#44](https://github.com/luarss/openroad-mcp/pull/44))
+- MCP integrations for Claude Desktop, Cursor, and GitHub Copilot ([#44](https://github.com/The-OpenROAD-Project/openroad-mcp/pull/44))
 - Documentation for MCP support across 14 major coding agents and IDEs
 
 ### Fixed
@@ -35,8 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Restored inline error patterns, dropped auto-update machinery
 
 ### Changed
-- Pinned all direct dependencies to exact versions ([#113](https://github.com/luarss/openroad-mcp/pull/113))
-- Bumped fastmcp ([#101](https://github.com/luarss/openroad-mcp/pull/101)), pillow ([#104](https://github.com/luarss/openroad-mcp/pull/104)), cryptography ([#103](https://github.com/luarss/openroad-mcp/pull/103)), pygments, and python-multipart ([#106](https://github.com/luarss/openroad-mcp/pull/106), [#110](https://github.com/luarss/openroad-mcp/pull/110))
+- Pinned all direct dependencies to exact versions ([#113](https://github.com/The-OpenROAD-Project/openroad-mcp/pull/113))
+- Bumped fastmcp ([#101](https://github.com/The-OpenROAD-Project/openroad-mcp/pull/101)), pillow ([#104](https://github.com/The-OpenROAD-Project/openroad-mcp/pull/104)), cryptography ([#103](https://github.com/The-OpenROAD-Project/openroad-mcp/pull/103)), pygments, and python-multipart ([#106](https://github.com/The-OpenROAD-Project/openroad-mcp/pull/106), [#110](https://github.com/The-OpenROAD-Project/openroad-mcp/pull/110))
 
 ## [0.4.2] - 2026-03-29
 
@@ -47,28 +47,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.4.0] - 2026-03-29
 
 ### Added
-- MCP registry publishing to release pipeline ([#93](https://github.com/luarss/openroad-mcp/pull/93))
-- Cross-platform validation and setup scripts ([#76](https://github.com/luarss/openroad-mcp/pull/76))
-- Comprehensive performance benchmarks for OpenROAD tool calls ([#84](https://github.com/luarss/openroad-mcp/pull/84))
+- MCP registry publishing to release pipeline ([#93](https://github.com/The-OpenROAD-Project/openroad-mcp/pull/93))
+- Cross-platform validation and setup scripts ([#76](https://github.com/The-OpenROAD-Project/openroad-mcp/pull/76))
+- Comprehensive performance benchmarks for OpenROAD tool calls ([#84](https://github.com/The-OpenROAD-Project/openroad-mcp/pull/84))
 
 ### Changed
-- Consolidated Dockerfile.test into unified multi-stage Dockerfile ([#88](https://github.com/luarss/openroad-mcp/pull/88))
-- Scaled concurrent session test to 50+ with p99/p95 latency metrics ([#86](https://github.com/luarss/openroad-mcp/pull/86))
+- Consolidated Dockerfile.test into unified multi-stage Dockerfile ([#88](https://github.com/The-OpenROAD-Project/openroad-mcp/pull/88))
+- Scaled concurrent session test to 50+ with p99/p95 latency metrics ([#86](https://github.com/The-OpenROAD-Project/openroad-mcp/pull/86))
 - Updated ROADMAP.md
 - Bumped requests dependency version
 
 ## [0.3.0] - 2026-03-25
 
 ### Added
-- Production Dockerfile with multi-stage build, non-root user, and GHCR publishing workflow ([#46](https://github.com/luarss/openroad-mcp/pull/46))
-- `--init` flag to docker run commands in Makefile for proper signal handling ([#80](https://github.com/luarss/openroad-mcp/pull/80))
+- Production Dockerfile with multi-stage build, non-root user, and GHCR publishing workflow ([#46](https://github.com/The-OpenROAD-Project/openroad-mcp/pull/46))
+- `--init` flag to docker run commands in Makefile for proper signal handling ([#80](https://github.com/The-OpenROAD-Project/openroad-mcp/pull/80))
 
 ### Fixed
-- Restored 15 skipped TestSessionManager tests ([#75](https://github.com/luarss/openroad-mcp/pull/75))
-- Replaced `cleanup()` with `cleanup_all()` in test_session_manager ([#73](https://github.com/luarss/openroad-mcp/pull/73))
+- Restored 15 skipped TestSessionManager tests ([#75](https://github.com/The-OpenROAD-Project/openroad-mcp/pull/75))
+- Replaced `cleanup()` with `cleanup_all()` in test_session_manager ([#73](https://github.com/The-OpenROAD-Project/openroad-mcp/pull/73))
 
 ### Changed
-- Removed dead `skip_fd_issues` marker and unused imports from test_interactive_pty.py ([#82](https://github.com/luarss/openroad-mcp/pull/82))
+- Removed dead `skip_fd_issues` marker and unused imports from test_interactive_pty.py ([#82](https://github.com/The-OpenROAD-Project/openroad-mcp/pull/82))
 
 ## [0.2.0] - 2026-03-18
 
@@ -103,11 +103,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - QUICKSTART guide, ARCHITECTURE, and CONTRIBUTING documentation
 - ROADMAP for planned features
 
-[0.5.3]: https://github.com/luarss/openroad-mcp/releases/tag/v0.5.3
-[0.5.0]: https://github.com/luarss/openroad-mcp/releases/tag/v0.5.0
-[0.4.2]: https://github.com/luarss/openroad-mcp/releases/tag/v0.4.2
-[0.4.1]: https://github.com/luarss/openroad-mcp/releases/tag/v0.4.1
-[0.4.0]: https://github.com/luarss/openroad-mcp/releases/tag/v0.4.0
-[0.3.0]: https://github.com/luarss/openroad-mcp/releases/tag/v0.3.0
-[0.2.0]: https://github.com/luarss/openroad-mcp/releases/tag/v0.2.0
-[0.1.0]: https://github.com/luarss/openroad-mcp/releases/tag/v0.1.0
+[0.5.3]: https://github.com/The-OpenROAD-Project/openroad-mcp/releases/tag/v0.5.3
+[0.5.0]: https://github.com/The-OpenROAD-Project/openroad-mcp/releases/tag/v0.5.0
+[0.4.2]: https://github.com/The-OpenROAD-Project/openroad-mcp/releases/tag/v0.4.2
+[0.4.1]: https://github.com/The-OpenROAD-Project/openroad-mcp/releases/tag/v0.4.1
+[0.4.0]: https://github.com/The-OpenROAD-Project/openroad-mcp/releases/tag/v0.4.0
+[0.3.0]: https://github.com/The-OpenROAD-Project/openroad-mcp/releases/tag/v0.3.0
+[0.2.0]: https://github.com/The-OpenROAD-Project/openroad-mcp/releases/tag/v0.2.0
+[0.1.0]: https://github.com/The-OpenROAD-Project/openroad-mcp/releases/tag/v0.1.0

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ MCP_REQUEST_MAX_TOTAL_TIMEOUT:= 99999999999
 DOCKER_TEST_IMAGE:= openroad-mcp-test
 ORFS_VERSION:= 26Q1-534-g510137693
 UV_VERSION:= 0.10.9
-IMAGE_NAME:= ghcr.io/luarss/openroad-mcp
+IMAGE_NAME:= ghcr.io/the-openroad-project/openroad-mcp
 
 .PHONY: sync
 sync:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenROAD MCP Server
 
-<!-- mcp-name: io.github.luarss/openroad-mcp -->
+<!-- mcp-name: io.github.the-openroad-project/openroad-mcp -->
 
 A Model Context Protocol (MCP) server that provides tools for interacting with OpenROAD and ORFS (OpenROAD Flow Scripts).
 
@@ -84,7 +84,7 @@ The basic configuration for all MCP clients:
       "command": "uvx",
       "args": [
         "--from",
-        "git+https://github.com/luarss/openroad-mcp@v0.5.3",
+        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.3",
         "openroad-mcp"
       ]
     }
@@ -94,7 +94,7 @@ The basic configuration for all MCP clients:
 
 > **Note:** The URL above is pinned to a specific release for supply chain safety.
 > To always track the latest version instead, drop the `@v0.5.3` suffix:
-> `"git+https://github.com/luarss/openroad-mcp@v0.5.3"`.
+> `"git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.3"`.
 
 For local development, use:
 
@@ -120,7 +120,7 @@ For local development, use:
 <summary><b>Claude Code</b></summary>
 
 ```bash
-claude mcp add --transport stdio openroad-mcp -- uvx --from git+https://github.com/luarss/openroad-mcp openroad-mcp
+claude mcp add --transport stdio openroad-mcp -- uvx --from git+https://github.com/The-OpenROAD-Project/openroad-mcp openroad-mcp
 ```
 
 Or add the [standard configuration](#standard-configuration) to `.claude/settings.json`.
@@ -156,7 +156,7 @@ Add to `.vscode/mcp.json` (VS Code 1.99+). Note the different schema — `server
       "command": "uvx",
       "args": [
         "--from",
-        "git+https://github.com/luarss/openroad-mcp@v0.5.3",
+        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.3",
         "openroad-mcp"
       ]
     }
@@ -195,7 +195,7 @@ Add to the Cline MCP settings file:
       "command": "uvx",
       "args": [
         "--from",
-        "git+https://github.com/luarss/openroad-mcp@v0.5.3",
+        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.3",
         "openroad-mcp"
       ],
       "disabled": false,
@@ -219,7 +219,7 @@ Add to `.roo/mcp.json` in your project root (or the equivalent user-level settin
       "command": "uvx",
       "args": [
         "--from",
-        "git+https://github.com/luarss/openroad-mcp@v0.5.3",
+        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.3",
         "openroad-mcp"
       ],
       "disabled": false,
@@ -246,7 +246,7 @@ Add to `~/.continue/config.json`:
           "command": "uvx",
           "args": [
             "--from",
-            "git+https://github.com/luarss/openroad-mcp@v0.5.3",
+            "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.3",
             "openroad-mcp"
           ]
         }
@@ -271,7 +271,7 @@ Add to `~/.config/zed/settings.json`:
         "path": "uvx",
         "args": [
           "--from",
-          "git+https://github.com/luarss/openroad-mcp@v0.5.3",
+          "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.3",
           "openroad-mcp"
         ]
       },
@@ -311,7 +311,7 @@ Add to your VS Code `settings.json` (User or Workspace scope):
         "command": "uvx",
         "args": [
           "--from",
-          "git+https://github.com/luarss/openroad-mcp@v0.5.3",
+          "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.3",
           "openroad-mcp"
         ]
       }
@@ -328,7 +328,7 @@ Add to your VS Code `settings.json` (User or Workspace scope):
 Open **Settings → AI → MCP Servers → Add New MCP Server** and enter:
 - **Name**: `openroad-mcp`
 - **Command**: `uvx`
-- **Args**: `--from git+https://github.com/luarss/openroad-mcp openroad-mcp`
+- **Args**: `--from git+https://github.com/The-OpenROAD-Project/openroad-mcp openroad-mcp`
 
 </details>
 
@@ -336,7 +336,7 @@ Open **Settings → AI → MCP Servers → Add New MCP Server** and enter:
 <summary><b>Amp</b></summary>
 
 ```bash
-amp mcp add openroad-mcp uvx --from git+https://github.com/luarss/openroad-mcp openroad-mcp
+amp mcp add openroad-mcp uvx --from git+https://github.com/The-OpenROAD-Project/openroad-mcp openroad-mcp
 ```
 
 </details>
@@ -361,7 +361,7 @@ Add to `opencode.json` in your project root:
       "command": [
         "uvx",
         "--from",
-        "git+https://github.com/luarss/openroad-mcp@v0.5.3",
+        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.3",
         "openroad-mcp"
       ],
       "enabled": true
@@ -391,7 +391,7 @@ Add to `.kilocode/mcp.json` in your project root:
       "command": "uvx",
       "args": [
         "--from",
-        "git+https://github.com/luarss/openroad-mcp@v0.5.3",
+        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.3",
         "openroad-mcp"
       ],
       "alwaysAllow": [],
@@ -416,7 +416,7 @@ extensions:
     cmd: uvx
     args:
       - --from
-      - git+https://github.com/luarss/openroad-mcp@v0.5.3
+      - git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.3
       - openroad-mcp
     enabled: true
 ```
@@ -438,7 +438,7 @@ Add to your VS Code `settings.json`:
           "command": "uvx",
           "args": [
             "--from",
-            "git+https://github.com/luarss/openroad-mcp@v0.5.3",
+            "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.3",
             "openroad-mcp"
           ]
         }
@@ -459,7 +459,7 @@ Add to `~/.codex/config.toml` (global) or `.codex/config.toml` (project-scoped):
 [[mcp_servers]]
 name = "openroad-mcp"
 command = "uvx"
-args = ["--from", "git+https://github.com/luarss/openroad-mcp@v0.5.3", "openroad-mcp"]
+args = ["--from", "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.3", "openroad-mcp"]
 ```
 
 </details>
@@ -479,7 +479,7 @@ PearAI uses the same config format as Continue. Add to `~/pearai/config.json`:
           "command": "uvx",
           "args": [
             "--from",
-            "git+https://github.com/luarss/openroad-mcp@v0.5.3",
+            "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.3",
             "openroad-mcp"
           ]
         }
@@ -503,7 +503,7 @@ Add to `~/.codebuddy/config.jsonc` (global) or `.codebuddy/mcp.jsonc` (project-s
       "command": "uvx",
       "args": [
         "--from",
-        "git+https://github.com/luarss/openroad-mcp@v0.5.3",
+        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.3",
         "openroad-mcp"
       ]
     }
@@ -525,7 +525,7 @@ mcp_servers:
     command: uvx
     args:
       - --from
-      - git+https://github.com/luarss/openroad-mcp@v0.5.3
+      - git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.3
       - openroad-mcp
 ```
 
@@ -544,7 +544,7 @@ Add to `~/.copilot/mcp-config.json`:
       "command": "uvx",
       "args": [
         "--from",
-        "git+https://github.com/luarss/openroad-mcp@v0.5.3",
+        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.3",
         "openroad-mcp"
       ]
     }
@@ -569,7 +569,7 @@ Add to `.omp/mcp.json` (project-level) or `~/.omp/agent/mcp.json` (global):
       "command": "uvx",
       "args": [
         "--from",
-        "git+https://github.com/luarss/openroad-mcp@v0.5.3",
+        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.3",
         "openroad-mcp"
       ]
     }
@@ -592,7 +592,7 @@ Add to `~/.openclaw/openclaw.json`:
         "command": "uvx",
         "args": [
           "--from",
-          "git+https://github.com/luarss/openroad-mcp@v0.5.3",
+          "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.3",
           "openroad-mcp"
         ],
         "enabled": true
@@ -614,7 +614,7 @@ Navigate to the AstrBot WebUI → **MCP** section → **Add Server**, and enter:
 ```json
 {
   "command": "uvx",
-  "args": ["--from", "git+https://github.com/luarss/openroad-mcp@v0.5.3", "openroad-mcp"]
+  "args": ["--from", "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.3", "openroad-mcp"]
 }
 ```
 
@@ -636,7 +636,7 @@ Add to `deepcode_config.json` in your project root:
         "command": "uvx",
         "args": [
           "--from",
-          "git+https://github.com/luarss/openroad-mcp@v0.5.3",
+          "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.3",
           "openroad-mcp"
         ]
       }
@@ -658,7 +658,7 @@ mcpServers:
     command: uvx
     args:
       - --from
-      - git+https://github.com/luarss/openroad-mcp@v0.5.3
+      - git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.3
       - openroad-mcp
 ```
 
@@ -677,7 +677,7 @@ Add to `.crush.json` (project-local) or `~/.config/crush/crush.json` (global):
       "command": "uvx",
       "args": [
         "--from",
-        "git+https://github.com/luarss/openroad-mcp@v0.5.3",
+        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.3",
         "openroad-mcp"
       ]
     }
@@ -696,7 +696,7 @@ Add to `reasonix.toml` (project root) or `~/.config/reasonix/config.toml` (globa
 [[plugins]]
 name    = "openroad-mcp"
 command = "uvx"
-args    = ["--from", "git+https://github.com/luarss/openroad-mcp@v0.5.3", "openroad-mcp"]
+args    = ["--from", "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.3", "openroad-mcp"]
 ```
 
 Alternatively, use the standard `.mcp.json` format — Reasonix auto-discovers it.
@@ -792,7 +792,7 @@ We welcome contributions to OpenROAD MCP! Please see [CONTRIBUTING.md](CONTRIBUT
 
 ## Support
 
-If you encounter any issues or have questions, please open an issue on our [GitHub issue tracker](https://github.com/luarss/openroad-mcp/issues).
+If you encounter any issues or have questions, please open an issue on our [GitHub issue tracker](https://github.com/The-OpenROAD-Project/openroad-mcp/issues).
 
 ## License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,8 +26,8 @@ The pre-release phase focuses on:
 4. **Documentation Quality** - Building comprehensive guides based on real user questions
 
 **Feedback Channels:**
-- [GitHub Issues](https://github.com/luarss/openroad-mcp/issues) - Bug reports and feature requests
-- [GitHub Discussions](https://github.com/luarss/openroad-mcp/discussions) - Questions and community discussion
+- [GitHub Issues](https://github.com/The-OpenROAD-Project/openroad-mcp/issues) - Bug reports and feature requests
+- [GitHub Discussions](https://github.com/The-OpenROAD-Project/openroad-mcp/discussions) - Questions and community discussion
 
 ---
 
@@ -224,8 +224,8 @@ We welcome community involvement at every stage:
 
 ## Feedback & Questions
 
-- **GitHub Issues:** [Report bugs and request features](https://github.com/luarss/openroad-mcp/issues)
-- **GitHub Discussions:** [Ask questions and share ideas](https://github.com/luarss/openroad-mcp/discussions)
+- **GitHub Issues:** [Report bugs and request features](https://github.com/The-OpenROAD-Project/openroad-mcp/issues)
+- **GitHub Discussions:** [Ask questions and share ideas](https://github.com/The-OpenROAD-Project/openroad-mcp/discussions)
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "openroad-mcp"
 version = "0.5.3"
 authors = [
-    {name = "Precision Innovations", email="jluar@precisioninno.com"},
+    {name = "Precision Innovations", email="it-support@precisioninno.com"},
 ]
 description = "The OpenROAD MCP server"
 readme = "README.md"

--- a/server.json
+++ b/server.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.luarss/openroad-mcp",
+  "name": "io.github.the-openroad-project/openroad-mcp",
   "description": "The OpenROAD MCP server - interactive EDA sessions via Model Context Protocol",
   "repository": {
-    "url": "https://github.com/luarss/openroad-mcp",
+    "url": "https://github.com/The-OpenROAD-Project/openroad-mcp",
     "source": "github"
   },
   "version": "0.5.3",
@@ -17,7 +17,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/luarss/openroad-mcp:0.5.3",
+      "identifier": "ghcr.io/the-openroad-project/openroad-mcp:0.5.3",
       "transport": { "type": "stdio" },
       "runtimeHint": "docker"
     }


### PR DESCRIPTION
## Summary

- Replace all `github.com/luarss/openroad-mcp` URLs with `github.com/The-OpenROAD-Project/openroad-mcp` across README, CHANGELOG, ROADMAP, server.json, Makefile, and workflows
- Update `ghcr.io/luarss/openroad-mcp` → `ghcr.io/the-openroad-project/openroad-mcp` in Makefile, docker-publish.yml, release.yml, and server.json
- Update MCP server name `io.github.luarss/openroad-mcp` → `io.github.the-openroad-project/openroad-mcp` in server.json and README
- Update author email in pyproject.toml from `jluar@precisioninno.com` to `it-support@precisioninno.com`

Resolves §3, §4, §5, §7 of issue #119.

## Remaining manual items (tracked in #119)

- Branch protection rules on `main`
- Team permissions (merge rights, release approvers)
- PyPI trusted publisher: add `The-OpenROAD-Project/OpenROAD-MCP`, workflow `release.yml`, env `pypi`; remove old `luarss` entry
- Contact MCP Registry to remove/redirect `io.github.luarss/openroad-mcp`
- Update `.claude/skills/release/SKILL.md` and `.claude/settings.json` (blocked from automated edit)
- Cut first release from new org repo (§8)

## Test plan

- [ ] CI passes on this PR
- [ ] `grep -r luarss .` returns only CHECKLIST.md and `.claude/` files