### PR TITLE
fix(ci): quote auto-tag if expression to avoid YAML parse error

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   tag:
     name: Create release tag
-    if: startsWith(github.event.head_commit.message, 'chore: release v')
+    if: "startsWith(github.event.head_commit.message, 'chore: release v')"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4


### PR DESCRIPTION
The `if` condition in `auto-tag.yml` contained a bare colon inside a single-quoted string, which the YAML parser treated as a mapping value delimiter.

**Fix:** wrap the entire expression in double quotes.

```yaml
# before
if: startsWith(github.event.head_commit.message, 'chore: release v')

# after
if: "startsWith(github.event.head_commit.message, 'chore: release v')"
```

`make check` passes cleanly after this change.