### PR TITLE
Feat/core manager whitelist

### DIFF
--- a/typescript/__tests__/config/command_whitelist.test.ts
+++ b/typescript/__tests__/config/command_whitelist.test.ts
@@ -282,6 +282,45 @@ describe("isCommandAllowed", () => {
   });
 });
 
+// splitlines() parity — bypass regression tests
+
+describe("line-boundary splitting (Python splitlines parity)", () => {
+  // Each of these separators must be treated as a statement boundary so that
+  // a blocked verb after the separator is not silently skipped.
+
+  it("blocks quit hidden after \\r (CR alone)", () => {
+    expect(isExecCommand("report_checks\rquit")).toEqual([false, "quit"]);
+  });
+
+  it("blocks quit hidden after \\r\\n (CRLF)", () => {
+    expect(isExecCommand("report_checks\r\nquit")).toEqual([false, "quit"]);
+  });
+
+  it("blocks quit hidden after \\v (vertical tab)", () => {
+    expect(isExecCommand("report_checks\vquit")).toEqual([false, "quit"]);
+  });
+
+  it("blocks quit hidden after \\f (form feed)", () => {
+    expect(isExecCommand("report_checks\fquit")).toEqual([false, "quit"]);
+  });
+
+  it("blocks quit hidden after \\x85 (NEL)", () => {
+    expect(isExecCommand("report_checks\x85quit")).toEqual([false, "quit"]);
+  });
+
+  it("blocks quit hidden after \\u2028 (line separator)", () => {
+    expect(isExecCommand("report_checks quit")).toEqual([false, "quit"]);
+  });
+
+  it("blocks quit hidden after \\u2029 (paragraph separator)", () => {
+    expect(isExecCommand("report_checks quit")).toEqual([false, "quit"]);
+  });
+
+  it("query tool also blocks exec-only verb hidden after \\r", () => {
+    expect(isQueryCommand("report_checks\rglobal_placement")).toEqual([false, "global_placement"]);
+  });
+});
+
 // minimatch vs fnmatch parity
 
 describe("glob parity (minimatch vs fnmatch)", () => {

--- a/typescript/__tests__/config/command_whitelist.test.ts
+++ b/typescript/__tests__/config/command_whitelist.test.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect } from "vitest";
+import {
+  BLOCKED_COMMANDS,
+  EXEC_ONLY_PATTERNS,
+  READONLY_PATTERNS,
+  extractVerb,
+  isCommandAllowed,
+  isExecCommand,
+  isQueryCommand,
+} from "../../src/config/command_whitelist.js";
+
+// extractVerb
+
+describe("extractVerb", () => {
+  it("returns a simple command", () => {
+    expect(extractVerb("report_checks")).toBe("report_checks");
+  });
+
+  it("returns only the first token for a command with args", () => {
+    expect(extractVerb("report_checks -path_delay max")).toBe("report_checks");
+  });
+
+  it("strips leading whitespace", () => {
+    expect(extractVerb("   get_nets  *")).toBe("get_nets");
+  });
+
+  it("returns null for an empty string", () => {
+    expect(extractVerb("")).toBeNull();
+  });
+
+  it("returns null for blank whitespace", () => {
+    expect(extractVerb("   ")).toBeNull();
+  });
+
+  it("returns null for a comment line", () => {
+    expect(extractVerb("# this is a comment")).toBeNull();
+  });
+
+  it("returns null for a comment with leading whitespace", () => {
+    expect(extractVerb("  # comment")).toBeNull();
+  });
+
+  it("returns $-prefixed tokens as-is for rejection", () => {
+    expect(extractVerb("$variable")).toBe("$variable");
+  });
+
+  it("returns [-prefixed tokens as-is for rejection", () => {
+    expect(extractVerb("[report_wns]")).toBe("[report_wns]");
+  });
+
+  it("strips a trailing semicolon", () => {
+    expect(extractVerb("puts;")).toBe("puts");
+  });
+});
+
+// Pattern set membership
+
+describe("pattern sets", () => {
+  it("READONLY contains report/get/check globs", () => {
+    expect(READONLY_PATTERNS).toContain("report_*");
+    expect(READONLY_PATTERNS).toContain("get_*");
+    expect(READONLY_PATTERNS).toContain("check_*");
+  });
+
+  it("READONLY contains Tcl builtins", () => {
+    expect(READONLY_PATTERNS).toContain("puts");
+    expect(READONLY_PATTERNS).toContain("foreach");
+    expect(READONLY_PATTERNS).toContain("set");
+  });
+
+  it("EXEC_ONLY contains set_*/read_*/write_* globs", () => {
+    expect(EXEC_ONLY_PATTERNS).toContain("set_*");
+    expect(EXEC_ONLY_PATTERNS).toContain("read_*");
+    expect(EXEC_ONLY_PATTERNS).toContain("write_*");
+  });
+
+  it("EXEC_ONLY contains flow commands", () => {
+    expect(EXEC_ONLY_PATTERNS).toContain("global_placement");
+    expect(EXEC_ONLY_PATTERNS).toContain("detailed_route");
+  });
+
+  it("EXEC_ONLY does not contain report_*", () => {
+    expect(EXEC_ONLY_PATTERNS).not.toContain("report_*");
+  });
+
+  it("READONLY does not contain set_* (exec-only setter)", () => {
+    expect(READONLY_PATTERNS).not.toContain("set_*");
+  });
+
+  it("ORFS file ops are exec-only, not blocked", () => {
+    for (const cmd of ["exec", "source", "exit", "open", "close", "file", "cd", "uplevel"]) {
+      expect(EXEC_ONLY_PATTERNS).toContain(cmd);
+      expect(BLOCKED_COMMANDS.has(cmd)).toBe(false);
+    }
+  });
+
+  it("BLOCKED contains all 10 OS-level commands", () => {
+    for (const cmd of [
+      "quit",
+      "socket",
+      "load",
+      "glob",
+      "fconfigure",
+      "chan",
+      "vwait",
+      "rename",
+      "after",
+      "subst",
+    ]) {
+      expect(BLOCKED_COMMANDS.has(cmd)).toBe(true);
+    }
+    expect(BLOCKED_COMMANDS.size).toBe(10);
+  });
+});
+
+// isQueryCommand
+
+describe("isQueryCommand", () => {
+  it("allows report_*", () => {
+    expect(isQueryCommand("report_checks -path_delay max")).toEqual([true, null]);
+  });
+
+  it("allows get_*", () => {
+    expect(isQueryCommand("get_nets *")).toEqual([true, null]);
+  });
+
+  it("allows check_*", () => {
+    expect(isQueryCommand("check_placement")).toEqual([true, null]);
+  });
+
+  it("allows sta", () => {
+    expect(isQueryCommand("sta")).toEqual([true, null]);
+  });
+
+  it("allows help", () => {
+    expect(isQueryCommand("help")).toEqual([true, null]);
+  });
+
+  it("allows puts", () => {
+    expect(isQueryCommand("puts hello")).toEqual([true, null]);
+  });
+
+  it("allows bare set (Tcl assignment)", () => {
+    expect(isQueryCommand("set x 42")).toEqual([true, null]);
+  });
+
+  it("blocks set_* (exec-only)", () => {
+    expect(isQueryCommand("set_clock_period -name clk 2.0")).toEqual([false, "set_clock_period"]);
+  });
+
+  it("blocks read_db (exec-only)", () => {
+    expect(isQueryCommand("read_db /path/to/design.odb")).toEqual([false, "read_db"]);
+  });
+
+  it("blocks write_db (exec-only)", () => {
+    expect(isQueryCommand("write_db /out/design.odb")).toEqual([false, "write_db"]);
+  });
+
+  it("blocks flow commands (exec-only)", () => {
+    expect(isQueryCommand("global_placement")).toEqual([false, "global_placement"]);
+  });
+
+  it("denies blocked exec", () => {
+    expect(isQueryCommand("exec ls -la")).toEqual([false, "exec"]);
+  });
+
+  it("blocks unknown commands as exec-only", () => {
+    expect(isQueryCommand("pdngen")).toEqual([false, "pdngen"]);
+  });
+
+  it("allows a comment-only line", () => {
+    expect(isQueryCommand("# comment")).toEqual([true, null]);
+  });
+
+  it("allows an empty command", () => {
+    expect(isQueryCommand("")).toEqual([true, null]);
+  });
+
+  it("allows a multiline all-readonly command", () => {
+    expect(isQueryCommand("report_checks\nreport_wns\nget_nets *")).toEqual([true, null]);
+  });
+
+  it("blocks a multiline command with one exec verb", () => {
+    expect(isQueryCommand("report_checks\nglobal_placement")).toEqual([false, "global_placement"]);
+  });
+
+  it("rejects [exec ls] without allowlist bypass", () => {
+    expect(isQueryCommand("[exec ls]")).toEqual([false, "[exec"]);
+  });
+
+  it("rejects $cmd without allowlist bypass", () => {
+    expect(isQueryCommand("$cmd")).toEqual([false, "$cmd"]);
+  });
+
+  it("splits on semicolons and rejects the offending verb", () => {
+    expect(isQueryCommand("report_wns; global_placement")).toEqual([false, "global_placement"]);
+  });
+});
+
+// isExecCommand
+
+describe("isExecCommand", () => {
+  it("allows set_clock_period", () => {
+    expect(isExecCommand("set_clock_period -name clk 2.0")).toEqual([true, null]);
+  });
+
+  it("allows create_clock", () => {
+    expect(isExecCommand("create_clock -name clk -period 2.0 [get_ports clk]")).toEqual([true, null]);
+  });
+
+  it("allows read_db / write_db", () => {
+    expect(isExecCommand("read_db /path/to/design.odb")).toEqual([true, null]);
+    expect(isExecCommand("write_db /out/design.odb")).toEqual([true, null]);
+  });
+
+  it("allows flow commands", () => {
+    expect(isExecCommand("global_placement")).toEqual([true, null]);
+  });
+
+  it("allows readonly commands (allow-by-default)", () => {
+    expect(isExecCommand("report_wns")).toEqual([true, null]);
+    expect(isExecCommand("get_nets *")).toEqual([true, null]);
+  });
+
+  it("allows puts and foreach", () => {
+    expect(isExecCommand("puts hello")).toEqual([true, null]);
+    expect(isExecCommand("foreach net [get_nets *] { puts $net }")).toEqual([true, null]);
+  });
+
+  it("allows unknown commands", () => {
+    expect(isExecCommand("pdngen")).toEqual([true, null]);
+  });
+
+  it("allows exec / source / exit (ORFS use)", () => {
+    expect(isExecCommand("exec yosys $::env(SCRIPTS_DIR)/synth.tcl")).toEqual([true, null]);
+    expect(isExecCommand("source $::env(SCRIPTS_DIR)/load.tcl")).toEqual([true, null]);
+    expect(isExecCommand("exit 1")).toEqual([true, null]);
+  });
+
+  it("allows open/close/file ops", () => {
+    expect(isExecCommand("open /tmp/report.log w")).toEqual([true, null]);
+    expect(isExecCommand("close $fh")).toEqual([true, null]);
+    expect(isExecCommand("file mkdir /results/6_final")).toEqual([true, null]);
+  });
+
+  it("blocks socket", () => {
+    expect(isExecCommand("socket tcp localhost 8080")).toEqual([false, "socket"]);
+  });
+
+  it("blocks quit", () => {
+    expect(isExecCommand("quit")).toEqual([false, "quit"]);
+  });
+
+  it("allows a multiline all-allowed command", () => {
+    expect(isExecCommand("read_db design.odb\nglobal_placement\nwrite_db out.odb")).toEqual([true, null]);
+  });
+
+  it("blocks a multiline command with one blocked verb", () => {
+    expect(isExecCommand("global_placement\nsocket tcp localhost")).toEqual([false, "socket"]);
+  });
+});
+
+// isCommandAllowed (backward-compat alias)
+
+describe("isCommandAllowed", () => {
+  it("mirrors isExecCommand for allowed commands", () => {
+    expect(isCommandAllowed("report_checks -path_delay max")).toEqual([true, null]);
+    expect(isCommandAllowed("read_db /path/to/design.odb")).toEqual([true, null]);
+    expect(isCommandAllowed("set_clock_period -name clk 2.0")).toEqual([true, null]);
+    expect(isCommandAllowed("global_placement")).toEqual([true, null]);
+    expect(isCommandAllowed("pdngen")).toEqual([true, null]);
+    expect(isCommandAllowed("exec yosys synth.tcl")).toEqual([true, null]);
+  });
+
+  it("allows a multi-statement command with semicolons", () => {
+    expect(isCommandAllowed("set x 1; report_wns; puts $x")).toEqual([true, null]);
+  });
+
+  it("blocks socket and gives it priority", () => {
+    expect(isCommandAllowed("socket tcp localhost 8080")).toEqual([false, "socket"]);
+    expect(isCommandAllowed("global_placement\nsocket tcp localhost")).toEqual([false, "socket"]);
+  });
+});
+
+// minimatch vs fnmatch parity
+
+describe("glob parity (minimatch vs fnmatch)", () => {
+  it("matches star-suffix against the empty remainder", () => {
+    // report_ / set_ / read_ match report_* / set_* / read_* (star matches empty)
+    expect(isQueryCommand("report_")).toEqual([true, null]);
+    expect(isExecCommand("set_")).toEqual([true, null]);
+    expect(isExecCommand("read_")).toEqual([true, null]);
+  });
+
+  it("is case-sensitive like POSIX fnmatch on verbs", () => {
+    // Report_Checks (capitalized) does not match report_* and is unknown -> blocked in query
+    expect(isQueryCommand("Report_Checks")).toEqual([false, "Report_Checks"]);
+  });
+});

--- a/typescript/__tests__/core/manager.test.ts
+++ b/typescript/__tests__/core/manager.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { Mock } from "vitest";
+import { OpenROADManager } from "../../src/core/manager.js";
+import { SessionError, SessionNotFoundError } from "../../src/interactive/models.js";
+import { InteractiveSession } from "../../src/interactive/session.js";
+import { SessionState } from "../../src/core/models.js";
+import type { SessionDetailedMetrics } from "../../src/core/models.js";
+
+// Stub the InteractiveSession constructor so the manager never spawns a PTY.
+vi.mock("../../src/interactive/session.js", () => {
+  return {
+    InteractiveSession: vi.fn(),
+  };
+});
+
+interface MockSession {
+  sessionId: string;
+  lastActivity: Date;
+  isAlive: Mock;
+  start: Mock;
+  sendCommand: Mock;
+  readOutput: Mock;
+  getInfo: Mock;
+  getDetailedMetrics: Mock;
+  getCommandHistory: Mock;
+  isIdleTimeout: Mock;
+  setSessionTimeout: Mock;
+  terminate: Mock;
+  cleanup: Mock;
+}
+
+function makeMockSession(sessionId: string, alive = true): MockSession {
+  const metrics: SessionDetailedMetrics = {
+    session_id: sessionId,
+    state: SessionState.ACTIVE,
+    is_alive: alive,
+    created_at: new Date().toISOString(),
+    last_activity: new Date().toISOString(),
+    uptime_seconds: 1,
+    idle_seconds: 0,
+    commands: { total_executed: 3, current_count: 3, history_length: 3 },
+    performance: { total_cpu_time: 0.5, peak_memory_mb: 10, current_memory_mb: 8 },
+    buffer: { current_size: 0, max_size: 1024, utilization_percent: 0 },
+    timeout: { configured_seconds: null, is_timed_out: false },
+  };
+
+  return {
+    sessionId,
+    lastActivity: new Date(),
+    isAlive: vi.fn().mockReturnValue(alive),
+    start: vi.fn().mockResolvedValue(undefined),
+    sendCommand: vi.fn().mockResolvedValue(undefined),
+    readOutput: vi.fn().mockResolvedValue({
+      output: "ok",
+      sessionId,
+      timestamp: new Date().toISOString(),
+      executionTime: 0.01,
+      commandCount: 1,
+      bufferSize: 0,
+      error: null,
+    }),
+    getInfo: vi.fn().mockResolvedValue({
+      sessionId,
+      createdAt: new Date().toISOString(),
+      isAlive: alive,
+      commandCount: 0,
+      bufferSize: 0,
+      uptimeSeconds: 1,
+      state: SessionState.ACTIVE,
+    }),
+    getDetailedMetrics: vi.fn().mockResolvedValue(metrics),
+    getCommandHistory: vi.fn().mockReturnValue([]),
+    isIdleTimeout: vi.fn().mockReturnValue(false),
+    setSessionTimeout: vi.fn(),
+    terminate: vi.fn().mockResolvedValue(undefined),
+    cleanup: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+const MockedSession = vi.mocked(InteractiveSession);
+
+describe("OpenROADManager", () => {
+  let manager: OpenROADManager;
+  let created: MockSession[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    created = [];
+    // Each `new InteractiveSession(id)` yields a fresh mock the test can inspect.
+    // A regular function (not an arrow) is required so it is constructable.
+    MockedSession.mockImplementation(function (this: unknown, sessionId: string) {
+      const mock = makeMockSession(sessionId);
+      created.push(mock);
+      return mock as unknown as InteractiveSession;
+    } as unknown as (sessionId: string) => InteractiveSession);
+    manager = new OpenROADManager(50);
+  });
+
+  describe("createSession", () => {
+    it("generates an 8-char id, starts the session, and stores it", async () => {
+      const id = await manager.createSession();
+      expect(id).toHaveLength(8);
+      expect(created).toHaveLength(1);
+      expect(created[0]!.start).toHaveBeenCalledOnce();
+      expect(manager.getSessionCount()).toBe(1);
+    });
+
+    it("honours an explicit session id and forwards start args", async () => {
+      const id = await manager.createSession({
+        sessionId: "abc",
+        command: ["openroad", "-no_init"],
+        env: { FOO: "bar" },
+        cwd: "/tmp",
+      });
+      expect(id).toBe("abc");
+      expect(created[0]!.start).toHaveBeenCalledWith(["openroad", "-no_init"], { FOO: "bar" }, "/tmp");
+    });
+
+    it("throws SessionError on a duplicate id", async () => {
+      await manager.createSession({ sessionId: "dup" });
+      await expect(manager.createSession({ sessionId: "dup" })).rejects.toBeInstanceOf(SessionError);
+    });
+
+    it("throws SessionError when at max capacity", async () => {
+      const limited = new OpenROADManager(1);
+      await limited.createSession({ sessionId: "s1" });
+      await expect(limited.createSession({ sessionId: "s2" })).rejects.toThrow(/Maximum session limit/);
+    });
+
+    it("falls back to the default buffer size when bufferSize is 0", async () => {
+      await manager.createSession({ sessionId: "zero", bufferSize: 0 });
+      // InteractiveSession is constructed with (sessionId, bufferSize); a 0 must
+      // not reach it - it would yield a zero-capacity buffer that drops output.
+      expect(MockedSession).toHaveBeenCalledWith("zero", expect.any(Number));
+      const bufArg = MockedSession.mock.calls[0]![1] as number;
+      expect(bufArg).toBeGreaterThan(0);
+    });
+
+    it("removes the placeholder when start() fails", async () => {
+      MockedSession.mockImplementationOnce(function (this: unknown, sessionId: string) {
+        const mock = makeMockSession(sessionId);
+        mock.start.mockRejectedValueOnce(new Error("spawn failed"));
+        created.push(mock);
+        return mock as unknown as InteractiveSession;
+      } as unknown as (sessionId: string) => InteractiveSession);
+      await expect(manager.createSession({ sessionId: "bad" })).rejects.toBeInstanceOf(SessionError);
+      expect(manager.getSessionCount()).toBe(0);
+    });
+  });
+
+  describe("executeCommand", () => {
+    it("delegates to sendCommand then readOutput", async () => {
+      await manager.createSession({ sessionId: "s1" });
+      const result = await manager.executeCommand("s1", "report_wns");
+      expect(created[0]!.sendCommand).toHaveBeenCalledWith("report_wns");
+      expect(created[0]!.readOutput).toHaveBeenCalledOnce();
+      expect(result.output).toBe("ok");
+    });
+
+    it("throws SessionNotFoundError for an unknown session", async () => {
+      await expect(manager.executeCommand("nope", "report_wns")).rejects.toBeInstanceOf(
+        SessionNotFoundError,
+      );
+    });
+
+    it("falls back to the default timeout when timeoutMs is 0", async () => {
+      await manager.createSession({ sessionId: "s1" });
+      await manager.executeCommand("s1", "report_wns", 0);
+      // 0 must not be forwarded as an instant timeout; readOutput gets the default.
+      const timeoutArg = created[0]!.readOutput.mock.calls[0]![0] as number;
+      expect(timeoutArg).toBeGreaterThan(0);
+    });
+  });
+
+  describe("listSessions", () => {
+    it("returns info for each active session", async () => {
+      await manager.createSession({ sessionId: "s1" });
+      await manager.createSession({ sessionId: "s2" });
+      const infos = await manager.listSessions();
+      expect(infos).toHaveLength(2);
+      expect(infos.map((i) => i.sessionId).sort()).toEqual(["s1", "s2"]);
+    });
+  });
+
+  describe("terminateSession", () => {
+    it("terminates, cleans up, and removes the session", async () => {
+      await manager.createSession({ sessionId: "s1" });
+      await manager.terminateSession("s1", true);
+      expect(created[0]!.terminate).toHaveBeenCalledWith(true);
+      expect(created[0]!.cleanup).toHaveBeenCalledOnce();
+      expect(manager.getSessionCount()).toBe(0);
+    });
+  });
+
+  describe("terminateAllSessions", () => {
+    it("terminates every session in parallel", async () => {
+      await manager.createSession({ sessionId: "s1" });
+      await manager.createSession({ sessionId: "s2" });
+      const count = await manager.terminateAllSessions();
+      expect(count).toBe(2);
+      expect(manager.getSessionCount()).toBe(0);
+    });
+  });
+
+  describe("inspectSession & getSessionHistory", () => {
+    it("inspectSession delegates to getDetailedMetrics", async () => {
+      await manager.createSession({ sessionId: "s1" });
+      const metrics = await manager.inspectSession("s1");
+      expect(created[0]!.getDetailedMetrics).toHaveBeenCalledOnce();
+      expect(metrics.session_id).toBe("s1");
+    });
+
+    it("getSessionHistory forwards limit and search", async () => {
+      await manager.createSession({ sessionId: "s1" });
+      await manager.getSessionHistory("s1", 5, "report");
+      expect(created[0]!.getCommandHistory).toHaveBeenCalledWith(5, "report");
+    });
+  });
+
+  describe("sessionMetrics", () => {
+    it("aggregates per-session metrics", async () => {
+      await manager.createSession({ sessionId: "s1" });
+      await manager.createSession({ sessionId: "s2" });
+      const metrics = await manager.sessionMetrics();
+      expect(metrics.manager.total_sessions).toBe(2);
+      expect(metrics.manager.active_sessions).toBe(2);
+      expect(metrics.aggregate.total_commands).toBe(6); // 3 per mock session
+      expect(metrics.sessions).toHaveLength(2);
+    });
+  });
+
+  describe("cleanupIdleSessions", () => {
+    it("terminates idle sessions and leaves active ones", async () => {
+      await manager.createSession({ sessionId: "idle" });
+      await manager.createSession({ sessionId: "busy" });
+      created[0]!.isIdleTimeout.mockReturnValue(true); // "idle"
+      created[1]!.isIdleTimeout.mockReturnValue(false); // "busy"
+
+      const cleaned = await manager.cleanupIdleSessions(300, true);
+      expect(cleaned).toBe(1);
+      expect(manager.getSessionCount()).toBe(1);
+    });
+  });
+
+  describe("_getSession behaviour via public methods", () => {
+    it("getSessionInfo throws SessionNotFoundError for an unknown id", async () => {
+      await expect(manager.getSessionInfo("ghost")).rejects.toBeInstanceOf(SessionNotFoundError);
+    });
+  });
+});

--- a/typescript/__tests__/interactive/session.test.ts
+++ b/typescript/__tests__/interactive/session.test.ts
@@ -598,4 +598,99 @@ describe("InteractiveSession", () => {
       expect(result.error).toMatch(/Design not found: top/);
     });
   });
+
+  describe("activity, history, and metrics", () => {
+    beforeEach(async () => {
+      (mockPty.isProcessAlive as ReturnType<typeof vi.fn>).mockReturnValue(true);
+      await session.start();
+    });
+
+    it("updates lastActivity and grows history on sendCommand", async () => {
+      const before = session.lastActivity.getTime();
+      await session.sendCommand("report_wns");
+
+      expect(session.commandHistory).toHaveLength(1);
+      expect(session.commandHistory[0]!.command).toBe("report_wns");
+      expect(session.commandHistory[0]!.command_number).toBe(1);
+      expect(typeof session.commandHistory[0]!.execution_start).toBe("number");
+      expect(session.totalCommandsExecuted).toBe(1);
+      expect(session.lastActivity.getTime()).toBeGreaterThanOrEqual(before);
+    });
+
+    it("trims the recorded command text", async () => {
+      await session.sendCommand("  puts hi  ");
+      expect(session.commandHistory[0]!.command).toBe("puts hi");
+    });
+
+    it("getCommandHistory filters by search (case-insensitive)", async () => {
+      await session.sendCommand("report_wns");
+      await session.sendCommand("get_nets foo");
+
+      const filtered = session.getCommandHistory(undefined, "REPORT");
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0]!.command).toBe("report_wns");
+    });
+
+    it("getCommandHistory applies a limit and sorts most-recent-first", async () => {
+      await session.sendCommand("cmd_a");
+      await session.sendCommand("cmd_b");
+      // Pin timestamps so the sort is deterministic regardless of wall-clock resolution.
+      session.commandHistory[0]!.timestamp = "2024-01-01T00:00:00.000Z";
+      session.commandHistory[1]!.timestamp = "2024-01-01T00:00:01.000Z";
+
+      const limited = session.getCommandHistory(1);
+      expect(limited).toHaveLength(1);
+      expect(limited[0]!.command).toBe("cmd_b");
+    });
+
+    it("getDetailedMetrics returns the full nested shape", async () => {
+      await session.sendCommand("report_wns");
+      const m = await session.getDetailedMetrics();
+
+      expect(m.session_id).toBe("test-session-1");
+      expect(m.is_alive).toBe(true);
+      expect(m.commands.total_executed).toBe(1);
+      expect(m.commands.history_length).toBe(1);
+      expect(m.buffer.max_size).toBe(1024);
+      expect(m.timeout.configured_seconds).toBeNull();
+      expect(m.timeout.is_timed_out).toBe(false);
+    });
+
+    it("isIdleTimeout is false right after activity, true past the threshold", async () => {
+      await session.sendCommand("report_wns");
+      expect(session.isIdleTimeout(1000)).toBe(false);
+
+      session.lastActivity = new Date(Date.now() - 10_000);
+      expect(session.isIdleTimeout(1)).toBe(true);
+    });
+
+    it("setSessionTimeout drives the uptime-based is_timed_out flag", async () => {
+      // is_timed_out compares configured timeout against wall-clock uptime
+      // (distinct from idle timeout). Push createdAt into the past so uptime
+      // deterministically exceeds the configured 1s timeout.
+      session.setSessionTimeout(1);
+      expect(session.sessionTimeoutSeconds).toBe(1);
+      session.createdAt.setTime(Date.now() - 10_000);
+
+      const m = await session.getDetailedMetrics();
+      expect(m.timeout.configured_seconds).toBe(1);
+      expect(m.timeout.is_timed_out).toBe(true);
+    });
+
+    it("readOutput backfills execution_time and output_length on the last entry", async () => {
+      await session.sendCommand("report_wns");
+      await session.outputBuffer.append("wns 0.1\n");
+      await session.readOutput(100);
+
+      const entry = session.commandHistory[0]!;
+      expect(entry.execution_time).toBeGreaterThanOrEqual(0);
+      expect(entry.output_length).toBeGreaterThan(0);
+    });
+
+    it("filterOutput returns matching lines (regex, case-insensitive)", async () => {
+      await session.outputBuffer.append("alpha\nbeta\ngamma beta\n");
+      const matches = await session.filterOutput("BETA");
+      expect(matches).toEqual(["beta", "gamma beta"]);
+    });
+  });
 });

--- a/typescript/src/config/command_whitelist.ts
+++ b/typescript/src/config/command_whitelist.ts
@@ -1,0 +1,229 @@
+/**
+ * Command filter for OpenROAD PTY session security.
+ *
+ * Prevents execution of dangerous OS-level Tcl commands by AI agents.
+ *
+ * Three-tier design:
+ *
+ *   BLOCKED_COMMANDS    - denied in both tools (OS-level Tcl built-ins that can
+ *                         escape the EDA sandbox)
+ *
+ *   EXEC_ONLY_PATTERNS  - explicitly known state-modifying commands; denied in
+ *                         the query tool, allowed in the exec tool
+ *
+ *   READONLY_PATTERNS   - explicitly known safe read-only commands; allowed in
+ *                         both tools
+ *
+ *   Unknown commands    - treated as exec-only: denied in the query tool,
+ *                         allowed in the exec tool (they will fail at the Tcl
+ *                         level if invalid)
+ *
+ * This is distinct from PtyHandler.validateCommand(), which guards the shell
+ * binary/args. This module guards the Tcl statements sent to the REPL.
+ */
+
+import { minimatch } from "minimatch";
+import { getLogger } from "../utils/logging.js";
+
+const logger = getLogger("command_whitelist");
+
+// Python uses fnmatch.fnmatch, which (unlike default glob) does not special-case
+// a leading dot. `dot: true` makes minimatch's `*` match leading dots too, so
+// single-token verb matching stays faithful to the Python implementation.
+const MINIMATCH_OPTS = { dot: true } as const;
+
+function matchVerb(verb: string, pattern: string): boolean {
+  return minimatch(verb, pattern, MINIMATCH_OPTS);
+}
+
+// Blocked commands - denied in both query and exec tools.
+export const BLOCKED_COMMANDS: ReadonlySet<string> = new Set([
+  "quit", // Terminate the OpenROAD process (ORFS uses exit instead)
+  "socket", // Network connections
+  "load", // Load compiled C extensions into the interpreter
+  "glob", // Filesystem enumeration
+  "fconfigure", // I/O channel configuration
+  "chan", // Channel operations
+  "vwait", // Block the event loop
+  "rename", // Renames/removes commands, can bypass top-level checks
+  "after", // Schedules arbitrary code execution
+  "subst", // Performs substitutions that can invoke arbitrary commands
+]);
+
+// Exec-only commands - denied in the query, allowed in the exec tool.
+// Unknown commands are implicitly exec-only and do not need to appear here.
+export const EXEC_ONLY_PATTERNS: readonly string[] = [
+  // ORFS file and process operations
+  "exec", // Run external tools (Yosys, KLayout, Python helpers)
+  "source", // Load Tcl scripts (primary ORFS script-loading mechanism)
+  "exit", // Process exit (used in ORFS error handlers)
+  "open", // Open file handles (reports, SDC files, metrics)
+  "close", // Close file handles
+  "file", // Filesystem ops: mkdir, delete, link, copy
+  "cd", // Change working directory (used in platform setup scripts)
+  "uplevel", // Evaluate in parent stack frame (used by ORFS log_cmd)
+  // OpenROAD constraints / design setup
+  "set_*",
+  "create_*",
+  // File I/O through OpenROAD wrappers
+  "read_*",
+  "write_*",
+  // OpenROAD flow commands
+  "initialize_floorplan",
+  "place_pins",
+  "global_placement",
+  "detailed_placement",
+  "clock_tree_synthesis",
+  "global_route",
+  "detailed_route",
+  "repair_design",
+  "repair_timing",
+  "repair_clock_nets",
+  // OpenROAD utility
+  "log_begin",
+  "log_end",
+];
+
+// Safe Tcl built-ins - usable in both tools.
+export const _TCL_BUILTINS: readonly string[] = [
+  "puts",
+  "set",
+  "expr",
+  "if",
+  "else",
+  "elseif",
+  "for",
+  "foreach",
+  "while",
+  "proc",
+  "return",
+  "break",
+  "continue",
+  "list",
+  "llength",
+  "lindex",
+  "lappend",
+  "lrange",
+  "lsort",
+  "lsearch",
+  "lreplace",
+  "string",
+  "regexp",
+  "regsub",
+  "format",
+  "scan",
+  "array",
+  "dict",
+  "catch",
+  "error",
+  "namespace",
+  "upvar",
+  "global",
+  "variable",
+  "concat",
+  "join",
+  "split",
+  "incr",
+  "append",
+  "info",
+  "unset",
+];
+
+// Read-only OpenROAD command patterns - allowed in the query tool.
+export const READONLY_PATTERNS: readonly string[] = [
+  // OpenROAD reporting
+  "report_*",
+  // OpenROAD design queries
+  "get_*",
+  // OpenROAD validation
+  "check_*",
+  // OpenROAD analysis
+  "estimate_parasitics",
+  "sta",
+  // OpenROAD utility
+  "help",
+  "version",
+  ..._TCL_BUILTINS,
+];
+
+/**
+ * Return the command verb (first token) of a single Tcl statement.
+ *
+ * Returns null only for blank lines and comment lines. Lines that start with a
+ * substitution or grouping character (`$`, `[`, `]`, `{`, `}`) are returned
+ * as-is so the caller can reject them via the allowlist.
+ */
+export function extractVerb(statement: string): string | null {
+  const stripped = statement.trim();
+  if (stripped === "" || stripped.startsWith("#")) {
+    return null;
+  }
+  const firstToken = stripped.split(/\s+/)[0]!;
+  return firstToken.replace(/;+$/, "");
+}
+
+/** Iterate the verbs of a command, mirroring Python's naive `;`->newline split. */
+function* iterVerbs(command: string): Generator<string> {
+  // Preserve the naive splitting behavior exactly: replace ';' with newline,
+  // then split into lines. Semicolons inside Tcl braces or quoted strings are
+  // not handled - this matches the Python implementation's known limitation.
+  for (const rawLine of command.replace(/;/g, "\n").split("\n")) {
+    const verb = extractVerb(rawLine);
+    if (verb !== null) {
+      yield verb;
+    }
+  }
+}
+
+/**
+ * Check whether `command` is safe for the read-only query tool.
+ *
+ * A verb is allowed only when it matches READONLY_PATTERNS and is not in
+ * BLOCKED_COMMANDS. Commands in EXEC_ONLY_PATTERNS and unknown commands are
+ * both treated as exec-only and are rejected here.
+ */
+export function isQueryCommand(command: string): [boolean, string | null] {
+  for (const verb of iterVerbs(command)) {
+    if (BLOCKED_COMMANDS.has(verb)) {
+      logger.warn(`Blocked command '${verb}' (explicit blocklist)`);
+      return [false, verb];
+    }
+
+    if (!READONLY_PATTERNS.some((pattern) => matchVerb(verb, pattern))) {
+      if (EXEC_ONLY_PATTERNS.some((pattern) => matchVerb(verb, pattern))) {
+        logger.warn(`Blocked command '${verb}' (exec-only, use the exec tool)`);
+      } else {
+        logger.warn(`Blocked command '${verb}' (unknown, treated as exec-only)`);
+      }
+      return [false, verb];
+    }
+  }
+
+  return [true, null];
+}
+
+/**
+ * Check whether `command` is safe for the state-modifying exec tool.
+ *
+ * Blocks only BLOCKED_COMMANDS (OS-level danger). All other commands -
+ * including EXEC_ONLY_PATTERNS, READONLY_PATTERNS, and unknown ones - are
+ * allowed; they will fail at the Tcl level if invalid.
+ */
+export function isExecCommand(command: string): [boolean, string | null] {
+  for (const verb of iterVerbs(command)) {
+    if (BLOCKED_COMMANDS.has(verb)) {
+      logger.warn(`Blocked command '${verb}' (explicit blocklist)`);
+      return [false, verb];
+    }
+  }
+
+  return [true, null];
+}
+
+/**
+ * Check `command` against BLOCKED_COMMANDS only (allow-by-default).
+ * Equivalent to isExecCommand. Kept for backward compatibility.
+ */
+export function isCommandAllowed(command: string): [boolean, string | null] {
+  return isExecCommand(command);
+}

--- a/typescript/src/config/command_whitelist.ts
+++ b/typescript/src/config/command_whitelist.ts
@@ -164,10 +164,13 @@ export function extractVerb(statement: string): string | null {
 
 /** Iterate the verbs of a command, mirroring Python's naive `;`->newline split. */
 function* iterVerbs(command: string): Generator<string> {
-  // Preserve the naive splitting behavior exactly: replace ';' with newline,
-  // then split into lines. Semicolons inside Tcl braces or quoted strings are
-  // not handled - this matches the Python implementation's known limitation.
-  for (const rawLine of command.replace(/;/g, "\n").split("\n")) {
+  // Replace ';' with newline, then split on all Unicode line boundaries that
+  // Python's str.splitlines() recognises. \r\n must precede \r so the pair is
+  // consumed as one separator. Semicolons inside Tcl braces or quoted strings
+  // are not handled - this matches the Python implementation's known limitation.
+  for (const rawLine of command
+    .replace(/;/g, "\n")
+    .split(/\r\n|[\n\r\v\f\x1c\x1d\x1e\x85\u2028\u2029]/)) {
     const verb = extractVerb(rawLine);
     if (verb !== null) {
       yield verb;

--- a/typescript/src/config/command_whitelist.ts
+++ b/typescript/src/config/command_whitelist.ts
@@ -22,19 +22,10 @@
  * binary/args. This module guards the Tcl statements sent to the REPL.
  */
 
-import { minimatch } from "minimatch";
+import { Minimatch } from "minimatch";
 import { getLogger } from "../utils/logging.js";
 
 const logger = getLogger("command_whitelist");
-
-// Python uses fnmatch.fnmatch, which (unlike default glob) does not special-case
-// a leading dot. `dot: true` makes minimatch's `*` match leading dots too, so
-// single-token verb matching stays faithful to the Python implementation.
-const MINIMATCH_OPTS = { dot: true } as const;
-
-function matchVerb(verb: string, pattern: string): boolean {
-  return minimatch(verb, pattern, MINIMATCH_OPTS);
-}
 
 // Blocked commands - denied in both query and exec tools.
 export const BLOCKED_COMMANDS: ReadonlySet<string> = new Set([
@@ -146,6 +137,20 @@ export const READONLY_PATTERNS: readonly string[] = [
   ..._TCL_BUILTINS,
 ];
 
+// Python uses fnmatch.fnmatch, which (unlike default glob) does not special-case
+// a leading dot. `dot: true` makes minimatch's `*` match leading dots too, so
+// single-token verb matching stays faithful to the Python implementation.
+const MINIMATCH_OPTS = { dot: true } as const;
+
+// Pre-compile all glob patterns once at module load (~30x faster than calling
+// minimatch() on every check, which recompiles the regex on each invocation).
+const EXEC_ONLY_MATCHERS = EXEC_ONLY_PATTERNS.map((p) => new Minimatch(p, MINIMATCH_OPTS));
+const READONLY_MATCHERS = READONLY_PATTERNS.map((p) => new Minimatch(p, MINIMATCH_OPTS));
+
+function matchesAny(verb: string, matchers: readonly Minimatch[]): boolean {
+  return matchers.some((m) => m.match(verb));
+}
+
 /**
  * Return the command verb (first token) of a single Tcl statement.
  *
@@ -192,8 +197,8 @@ export function isQueryCommand(command: string): [boolean, string | null] {
       return [false, verb];
     }
 
-    if (!READONLY_PATTERNS.some((pattern) => matchVerb(verb, pattern))) {
-      if (EXEC_ONLY_PATTERNS.some((pattern) => matchVerb(verb, pattern))) {
+    if (!matchesAny(verb, READONLY_MATCHERS)) {
+      if (matchesAny(verb, EXEC_ONLY_MATCHERS)) {
         logger.warn(`Blocked command '${verb}' (exec-only, use the exec tool)`);
       } else {
         logger.warn(`Blocked command '${verb}' (unknown, treated as exec-only)`);

--- a/typescript/src/core/manager.ts
+++ b/typescript/src/core/manager.ts
@@ -1,0 +1,330 @@
+import { Mutex } from "async-mutex";
+import { randomUUID } from "node:crypto";
+import { getSettings } from "../config/settings.js";
+import type { Settings } from "../config/settings.js";
+import { getLogger } from "../utils/logging.js";
+import { InteractiveSession } from "../interactive/session.js";
+import { SessionError, SessionNotFoundError } from "../interactive/models.js";
+import type {
+  CommandHistoryEntry,
+  InteractiveExecResult,
+  InteractiveSessionInfo,
+  ManagerMetrics,
+  SessionDetailedMetrics,
+} from "./models.js";
+
+/** Time after which a dead session is force-removed even if cleanup fails. */
+const FORCE_CLEANUP_AFTER_SECONDS = 60;
+
+export interface CreateSessionOptions {
+  sessionId?: string;
+  command?: string[];
+  env?: Record<string, string>;
+  cwd?: string;
+  bufferSize?: number;
+}
+
+/**
+ * Manages OpenROAD subprocess lifecycle and interactive sessions.
+ *
+ * Node.js is single-threaded, so no reentrant lock is needed for plain state
+ * access (Python used asyncio.Lock + the GIL). The async-mutex `cleanupLock`
+ * serialises the multi-await cleanup/creation sections so concurrent callers
+ * cannot interleave session-map mutations across await points.
+ *
+ * The module exports a shared `manager` singleton; the class is exported too so
+ * tests can construct isolated instances.
+ */
+export class OpenROADManager {
+  private readonly logger = getLogger("manager");
+  private readonly sessions = new Map<string, InteractiveSession | null>();
+  private readonly cleanupLock = new Mutex();
+  private readonly settings: Settings = getSettings();
+  private readonly maxSessions: number;
+  private readonly defaultTimeoutMs: number;
+  private readonly defaultBufferSize: number;
+
+  constructor(maxSessions?: number) {
+    this.maxSessions = maxSessions ?? this.settings.MAX_SESSIONS;
+    this.defaultTimeoutMs = Math.round(this.settings.COMMAND_TIMEOUT * 1000);
+    this.defaultBufferSize = this.settings.DEFAULT_BUFFER_SIZE;
+    this.logger.info(`Initialized OpenROADManager with maxSessions=${this.maxSessions}`);
+  }
+
+  async createSession(opts: CreateSessionOptions = {}): Promise<string> {
+    const sessionId = opts.sessionId ?? randomUUID().slice(0, 8);
+
+    return this.cleanupLock.runExclusive(async () => {
+      await this._cleanupTerminatedSessions();
+
+      if (this.sessions.has(sessionId)) {
+        throw new SessionError(`Session ${sessionId} already exists`, sessionId);
+      }
+
+      const activeCount = this._countActive();
+      if (activeCount >= this.maxSessions) {
+        throw new SessionError(
+          `Maximum session limit reached (${this.maxSessions}). Currently ${activeCount} active sessions.`,
+          sessionId,
+        );
+      }
+
+      // Placeholder distinguishes "creating" (null) from "not found" (absent).
+      this.sessions.set(sessionId, null);
+
+      try {
+        // Match Python's `buffer_size or default`: 0 (and undefined) fall back
+        // to the default so a zero-capacity buffer can't silently drop all output.
+        const bufferSize = opts.bufferSize && opts.bufferSize > 0 ? opts.bufferSize : this.defaultBufferSize;
+        const session = new InteractiveSession(sessionId, bufferSize);
+        await session.start(opts.command, opts.env, opts.cwd);
+
+        this.sessions.set(sessionId, session);
+        this.logger.info(`Created session ${sessionId}, total sessions: ${this.sessions.size}`);
+        return sessionId;
+      } catch (e) {
+        this.sessions.delete(sessionId);
+        this.logger.error(`Failed to create session ${sessionId}: ${String(e)}`);
+        throw new SessionError(`Failed to create session: ${String(e)}`, sessionId);
+      }
+    });
+  }
+
+  async executeCommand(sessionId: string, command: string, timeoutMs?: number): Promise<InteractiveExecResult> {
+    const session = this._getSession(sessionId);
+    // Match Python's `timeout_ms or default`: 0 (and undefined) fall back to the
+    // configured default rather than becoming an instant timeout.
+    const actualTimeout = timeoutMs && timeoutMs > 0 ? timeoutMs : this.defaultTimeoutMs;
+
+    await session.sendCommand(command);
+    return session.readOutput(actualTimeout);
+  }
+
+  async getSessionInfo(sessionId: string): Promise<InteractiveSessionInfo> {
+    return this._getSession(sessionId).getInfo();
+  }
+
+  async listSessions(): Promise<InteractiveSessionInfo[]> {
+    await this._cleanupTerminatedSessionsWithLock();
+
+    const infos: InteractiveSessionInfo[] = [];
+    for (const [, session] of this._initializedSessions()) {
+      try {
+        infos.push(await session.getInfo());
+      } catch (e) {
+        this.logger.warn(`Failed to get info for session ${session.sessionId}: ${String(e)}`);
+      }
+    }
+    return infos;
+  }
+
+  async terminateSession(sessionId: string, force = false): Promise<void> {
+    const session = this._getSession(sessionId);
+
+    await session.terminate(force);
+    await session.cleanup();
+    this.logger.info(`Terminated session ${sessionId}`);
+
+    await this.cleanupLock.runExclusive(() => {
+      this.sessions.delete(sessionId);
+    });
+  }
+
+  async terminateAllSessions(force = false): Promise<number> {
+    const sessionIds = [...this.sessions.keys()];
+    if (sessionIds.length === 0) return 0;
+
+    const results = await Promise.allSettled(
+      sessionIds.map((sid) => this.terminateSession(sid, force)),
+    );
+    const terminated = results.filter((r) => r.status === "fulfilled").length;
+
+    this.logger.info(`Terminated ${terminated}/${sessionIds.length} sessions`);
+    return terminated;
+  }
+
+  async inspectSession(sessionId: string): Promise<SessionDetailedMetrics> {
+    return this._getSession(sessionId).getDetailedMetrics();
+  }
+
+  async getSessionHistory(sessionId: string, limit?: number, search?: string): Promise<CommandHistoryEntry[]> {
+    return this._getSession(sessionId).getCommandHistory(limit, search);
+  }
+
+  async replayCommand(sessionId: string, commandNumber: number): Promise<string> {
+    return this._getSession(sessionId).replayCommand(commandNumber);
+  }
+
+  async filterSessionOutput(sessionId: string, pattern: string, maxLines = 1000): Promise<string[]> {
+    return this._getSession(sessionId).filterOutput(pattern, maxLines);
+  }
+
+  async setSessionTimeout(sessionId: string, timeoutSeconds: number): Promise<void> {
+    this._getSession(sessionId).setSessionTimeout(timeoutSeconds);
+  }
+
+  async sessionMetrics(): Promise<ManagerMetrics> {
+    await this._cleanupTerminatedSessionsWithLock();
+
+    const totalSessions = this.sessions.size;
+    const activeSessions = this.getActiveSessionCount();
+    const terminatedSessions = totalSessions - activeSessions;
+
+    const sessionDetails: SessionDetailedMetrics[] = [];
+    let totalCommands = 0;
+    let totalCpuTime = 0;
+    let totalMemoryMb = 0;
+
+    for (const [, session] of this._initializedSessions()) {
+      try {
+        const metrics = await session.getDetailedMetrics();
+        sessionDetails.push(metrics);
+        totalCommands += metrics.commands.total_executed;
+        totalCpuTime += metrics.performance.total_cpu_time;
+        totalMemoryMb += metrics.performance.current_memory_mb;
+      } catch (e) {
+        this.logger.warn(`Failed to get metrics for session ${session.sessionId}: ${String(e)}`);
+      }
+    }
+
+    return {
+      manager: {
+        total_sessions: totalSessions,
+        active_sessions: activeSessions,
+        terminated_sessions: terminatedSessions,
+        max_sessions: this.maxSessions,
+        utilization_percent: this.maxSessions > 0 ? (activeSessions / this.maxSessions) * 100 : 0,
+      },
+      aggregate: {
+        total_commands: totalCommands,
+        total_cpu_time: totalCpuTime,
+        total_memory_mb: totalMemoryMb,
+        avg_memory_per_session: activeSessions > 0 ? totalMemoryMb / activeSessions : 0,
+      },
+      sessions: sessionDetails,
+    };
+  }
+
+  async cleanupIdleSessions(idleThresholdSeconds = 300, force = false): Promise<number> {
+    let cleaned = 0;
+    for (const [sessionId, session] of this._initializedSessions()) {
+      try {
+        if (session.isIdleTimeout(idleThresholdSeconds)) {
+          await this.terminateSession(sessionId, force);
+          cleaned++;
+          this.logger.info(`Cleaned up idle session ${sessionId}`);
+        }
+      } catch (e) {
+        this.logger.error(`Error checking idle status for session ${sessionId}: ${String(e)}`);
+      }
+    }
+    return cleaned;
+  }
+
+  async cleanupAll(): Promise<void> {
+    this.logger.info("Starting OpenROAD cleanup");
+
+    await this.terminateAllSessions(true);
+
+    await this.cleanupLock.runExclusive(async () => {
+      for (const [, session] of this._initializedSessions()) {
+        try {
+          await session.cleanup();
+        } catch (e) {
+          this.logger.warn(`Error during session cleanup: ${String(e)}`);
+        }
+      }
+      this.sessions.clear();
+    });
+
+    this.logger.info("OpenROAD cleanup completed");
+  }
+
+  getSessionCount(): number {
+    return this.sessions.size;
+  }
+
+  getActiveSessionCount(): number {
+    return this._countActive();
+  }
+
+  // internals
+
+  private _countActive(): number {
+    let count = 0;
+    for (const session of this.sessions.values()) {
+      if (session !== null && session.isAlive()) count++;
+    }
+    return count;
+  }
+
+  private _initializedSessions(): Array<[string, InteractiveSession]> {
+    const result: Array<[string, InteractiveSession]> = [];
+    for (const [sid, session] of this.sessions) {
+      if (session !== null) result.push([sid, session]);
+    }
+    return result;
+  }
+
+  private _getSession(sessionId: string): InteractiveSession {
+    if (!this.sessions.has(sessionId)) {
+      throw new SessionNotFoundError(`Session ${sessionId} not found`, sessionId);
+    }
+    const session = this.sessions.get(sessionId);
+    if (session == null) {
+      throw new SessionError(`Session ${sessionId} is still being created`, sessionId);
+    }
+    return session;
+  }
+
+  private async _cleanupTerminatedSessionsWithLock(): Promise<number> {
+    return this.cleanupLock.runExclusive(() => this._cleanupTerminatedSessions());
+  }
+
+  private async _cleanupTerminatedSessions(): Promise<number> {
+    const now = Date.now();
+    const terminated: Array<[string, InteractiveSession, boolean]> = [];
+
+    for (const [sessionId, session] of this._initializedSessions()) {
+      if (!session.isAlive()) {
+        const timeSinceDeath = (now - session.lastActivity.getTime()) / 1000;
+        terminated.push([sessionId, session, timeSinceDeath > FORCE_CLEANUP_AFTER_SECONDS]);
+      }
+    }
+
+    let cleaned = 0;
+    for (const [sessionId, session, forceCleanup] of terminated) {
+      try {
+        if (forceCleanup) {
+          this.logger.warn(`Force cleaning up session ${sessionId} after ${FORCE_CLEANUP_AFTER_SECONDS}s`);
+          try {
+            await session.cleanup();
+          } catch (cleanupError) {
+            this.logger.error(`Force cleanup failed for session ${sessionId}: ${String(cleanupError)}`);
+          } finally {
+            this.sessions.delete(sessionId);
+            cleaned++;
+          }
+        } else {
+          await session.cleanup();
+          this.sessions.delete(sessionId);
+          cleaned++;
+        }
+      } catch (e) {
+        this.logger.error(`Error during session ${sessionId} cleanup: ${String(e)}`);
+        if (forceCleanup && this.sessions.has(sessionId)) {
+          this.sessions.delete(sessionId);
+          cleaned++;
+        }
+      }
+    }
+
+    if (cleaned > 0) {
+      this.logger.info(`Cleaned up ${cleaned} terminated sessions`);
+    }
+    return cleaned;
+  }
+}
+
+/** Shared process-wide manager instance used by the MCP tools. */
+export const manager = new OpenROADManager();

--- a/typescript/src/core/models.ts
+++ b/typescript/src/core/models.ts
@@ -1,9 +1,22 @@
+import { z } from "zod";
+
 export enum SessionState {
   CREATING = "creating",
   ACTIVE = "active",
   TERMINATED = "terminated",
   ERROR = "error",
 }
+
+export enum ProcessState {
+  STOPPED = "stopped",
+  STARTING = "starting",
+  RUNNING = "running",
+  ERROR = "error",
+}
+
+// Domain interfaces (camelCase)
+// These remain plain interfaces and are converted to the snake_case MCP wire
+// format at the tool serialization boundary (BaseTool.formatResult, Part 2).
 
 export interface InteractiveSessionInfo {
   sessionId: string;
@@ -25,3 +38,164 @@ export interface InteractiveExecResult {
   bufferSize: number;
   error?: string | null;
 }
+
+// Opaque snake_case payloads
+// These are passed straight through to the wire (no camel->snake conversion),
+// matching Python's dict output byte-for-byte.
+
+/** One entry in a session's command history. */
+export interface CommandHistoryEntry {
+  command: string;
+  timestamp: string;
+  command_number: number;
+  execution_start: number;
+  execution_time?: number;
+  output_length?: number;
+}
+
+/** Detailed per-session metrics returned by InteractiveSession.getDetailedMetrics. */
+export interface SessionDetailedMetrics {
+  session_id: string;
+  state: string;
+  is_alive: boolean;
+  created_at: string;
+  last_activity: string;
+  uptime_seconds: number;
+  idle_seconds: number;
+  commands: {
+    total_executed: number;
+    current_count: number;
+    history_length: number;
+  };
+  performance: {
+    total_cpu_time: number;
+    peak_memory_mb: number;
+    current_memory_mb: number;
+  };
+  buffer: {
+    current_size: number;
+    max_size: number;
+    utilization_percent: number;
+  };
+  timeout: {
+    configured_seconds: number | null;
+    is_timed_out: boolean;
+  };
+}
+
+/** Aggregate metrics across all sessions returned by OpenROADManager.sessionMetrics. */
+export interface ManagerMetrics {
+  manager: {
+    total_sessions: number;
+    active_sessions: number;
+    terminated_sessions: number;
+    max_sessions: number;
+    utilization_percent: number;
+  };
+  aggregate: {
+    total_commands: number;
+    total_cpu_time: number;
+    total_memory_mb: number;
+    avg_memory_per_session: number;
+  };
+  sessions: SessionDetailedMetrics[];
+}
+
+// Zod result schemas
+// BaseResult pattern: every result carries `error: string | null`, defaulting to
+// null. Python Pydantic always emits the `error` key (`= None` -> `null`), so we
+// use `.nullable().default(null)`, never `.optional()`, to preserve key presence.
+
+const errorField = z.string().nullable().default(null);
+
+export const CommandRecord = z.object({
+  command: z.string(),
+  timestamp: z.string(),
+  id: z.number(),
+});
+export type CommandRecord = z.infer<typeof CommandRecord>;
+
+export const InteractiveSessionListResult = z.object({
+  sessions: z.array(z.custom<InteractiveSessionInfo>()).default([]),
+  totalCount: z.number().default(0),
+  activeCount: z.number().default(0),
+  error: errorField,
+});
+export type InteractiveSessionListResult = z.infer<typeof InteractiveSessionListResult>;
+
+export const SessionTerminationResult = z.object({
+  sessionId: z.string(),
+  terminated: z.boolean(),
+  wasAlive: z.boolean().default(false),
+  force: z.boolean().default(false),
+  error: errorField,
+});
+export type SessionTerminationResult = z.infer<typeof SessionTerminationResult>;
+
+export const SessionInspectionResult = z.object({
+  sessionId: z.string(),
+  metrics: z.custom<SessionDetailedMetrics>().nullable().default(null),
+  error: errorField,
+});
+export type SessionInspectionResult = z.infer<typeof SessionInspectionResult>;
+
+export const SessionHistoryResult = z.object({
+  sessionId: z.string(),
+  history: z.array(z.custom<CommandHistoryEntry>()).default([]),
+  totalCommands: z.number().default(0),
+  limit: z.number().nullable().default(null),
+  search: z.string().nullable().default(null),
+  error: errorField,
+});
+export type SessionHistoryResult = z.infer<typeof SessionHistoryResult>;
+
+export const SessionMetricsResult = z.object({
+  metrics: z.custom<ManagerMetrics>().nullable().default(null),
+  error: errorField,
+});
+export type SessionMetricsResult = z.infer<typeof SessionMetricsResult>;
+
+// Image models
+
+export const ImageInfo = z.object({
+  filename: z.string(),
+  path: z.string(),
+  sizeBytes: z.number(),
+  modifiedTime: z.string(),
+  type: z.string(),
+});
+export type ImageInfo = z.infer<typeof ImageInfo>;
+
+export const ImageMetadata = z.object({
+  filename: z.string(),
+  format: z.string(),
+  sizeBytes: z.number(),
+  width: z.number().nullable().default(null),
+  height: z.number().nullable().default(null),
+  modifiedTime: z.string(),
+  stage: z.string(),
+  type: z.string(),
+  compressionApplied: z.boolean().default(false),
+  originalSizeBytes: z.number().nullable().default(null),
+  originalWidth: z.number().nullable().default(null),
+  originalHeight: z.number().nullable().default(null),
+  compressionRatio: z.number().nullable().default(null),
+});
+export type ImageMetadata = z.infer<typeof ImageMetadata>;
+
+export const ListImagesResult = z.object({
+  runPath: z.string().nullable().default(null),
+  totalImages: z.number().nullable().default(null),
+  imagesByStage: z.record(z.string(), z.array(ImageInfo)).nullable().default(null),
+  message: z.string().nullable().default(null),
+  error: errorField,
+});
+export type ListImagesResult = z.infer<typeof ListImagesResult>;
+
+export const ReadImageResult = z.object({
+  imageData: z.string().nullable().default(null),
+  metadata: ImageMetadata.nullable().default(null),
+  message: z.string().nullable().default(null),
+  error: errorField,
+});
+export type ReadImageResult = z.infer<typeof ReadImageResult>;

--- a/typescript/src/core/models.ts
+++ b/typescript/src/core/models.ts
@@ -102,18 +102,12 @@ export interface ManagerMetrics {
 }
 
 // Zod result schemas
-// BaseResult pattern: every result carries `error: string | null`, defaulting to
-// null. Python Pydantic always emits the `error` key (`= None` -> `null`), so we
-// use `.nullable().default(null)`, never `.optional()`, to preserve key presence.
+// Mirrors Python's Pydantic models in core/models.py. Every result carries
+// `error: string | null` (defaulting to null) matching Pydantic's `= None`
+// serialization. These are wired up at the tool serialization boundary
+// (BaseTool.formatResult, Part 2).
 
 const errorField = z.string().nullable().default(null);
-
-export const CommandRecord = z.object({
-  command: z.string(),
-  timestamp: z.string(),
-  id: z.number(),
-});
-export type CommandRecord = z.infer<typeof CommandRecord>;
 
 export const InteractiveSessionListResult = z.object({
   sessions: z.array(z.custom<InteractiveSessionInfo>()).default([]),
@@ -199,3 +193,4 @@ export const ReadImageResult = z.object({
   error: errorField,
 });
 export type ReadImageResult = z.infer<typeof ReadImageResult>;
+

--- a/typescript/src/interactive/pty_handler.ts
+++ b/typescript/src/interactive/pty_handler.ts
@@ -15,6 +15,11 @@ export class PtyHandler {
 
   constructor(private readonly _settings: Settings = getSettings()) {}
 
+  /** PID of the underlying PTY process, or null if no process is active. */
+  get pid(): number | null {
+    return this._ptyProcess?.pid ?? null;
+  }
+
   validateCommand(command: string[]): void {
     if (!this._settings.ENABLE_COMMAND_VALIDATION) return;
 

--- a/typescript/src/interactive/session.ts
+++ b/typescript/src/interactive/session.ts
@@ -366,26 +366,17 @@ export class InteractiveSession {
   }
 
   /** Sample CPU/memory from the live process. Best-effort; silently ignores a
-   * dead or inaccessible PID. CPU time is cumulative (assigned, not summed). */
-  private async _updatePerformanceMetrics(): Promise<void> {
+   * dead or inaccessible PID. CPU time is cumulative (assigned, not summed).
+   * Returns current memory MB so callers can avoid a second pidusage() call. */
+  private async _updatePerformanceMetrics(): Promise<number> {
     const pid = this.pty.pid;
-    if (pid == null) return;
+    if (pid == null) return 0;
     try {
       const usage = await pidusage(pid);
       this.totalCpuTime = usage.ctime / 1000;
       const currentMemoryMb = Math.max(0, usage.memory) / BYTES_TO_MB;
       this.peakMemoryMb = Math.max(this.peakMemoryMb, currentMemoryMb);
-    } catch {
-      // Process may have exited or be inaccessible.
-    }
-  }
-
-  private async _getCurrentMemoryMb(): Promise<number> {
-    const pid = this.pty.pid;
-    if (pid == null) return 0;
-    try {
-      const usage = await pidusage(pid);
-      return Math.max(0, usage.memory) / BYTES_TO_MB;
+      return currentMemoryMb;
     } catch {
       return 0;
     }
@@ -400,7 +391,7 @@ export class InteractiveSession {
   }
 
   async getDetailedMetrics(): Promise<SessionDetailedMetrics> {
-    await this._updatePerformanceMetrics();
+    const currentMemoryMb = await this._updatePerformanceMetrics();
     const now = Date.now();
     const uptimeSeconds = (now - this.createdAt.getTime()) / 1000;
     const idleSeconds = (now - this.lastActivity.getTime()) / 1000;
@@ -423,7 +414,7 @@ export class InteractiveSession {
       performance: {
         total_cpu_time: this.totalCpuTime,
         peak_memory_mb: this.peakMemoryMb,
-        current_memory_mb: await this._getCurrentMemoryMb(),
+        current_memory_mb: currentMemoryMb,
       },
       buffer: {
         current_size: bufferSize,

--- a/typescript/src/interactive/session.ts
+++ b/typescript/src/interactive/session.ts
@@ -1,9 +1,15 @@
+import pidusage from "pidusage";
 import { ANSIDecoder } from "../utils/ansi_decoder.js";
 import { getSettings } from "../config/settings.js";
 import type { Settings } from "../config/settings.js";
 import { SessionState } from "../core/models.js";
-import type { InteractiveExecResult, InteractiveSessionInfo } from "../core/models.js";
-import { MAX_COMMAND_COMPLETION_WINDOW } from "../constants.js";
+import type {
+  CommandHistoryEntry,
+  InteractiveExecResult,
+  InteractiveSessionInfo,
+  SessionDetailedMetrics,
+} from "../core/models.js";
+import { BYTES_TO_MB, MAX_COMMAND_COMPLETION_WINDOW, UTILIZATION_PERCENTAGE_BASE } from "../constants.js";
 import { CircularBuffer } from "./buffer.js";
 import { SessionError, SessionTerminatedError } from "./models.js";
 import { PtyHandler } from "./pty_handler.js";
@@ -32,6 +38,14 @@ export class InteractiveSession {
   readonly sessionId: string;
   readonly createdAt: Date;
   commandCount = 0;
+
+  // Activity / history / performance tracking (consumed by the manager).
+  lastActivity: Date = new Date();
+  readonly commandHistory: CommandHistoryEntry[] = [];
+  totalCpuTime = 0;
+  peakMemoryMb = 0;
+  totalCommandsExecuted = 0;
+  sessionTimeoutSeconds: number | null = null;
 
   private _state: SessionState;
   pty: PtyHandler;
@@ -141,9 +155,20 @@ export class InteractiveSession {
       );
     }
 
+    // Record the command in history before bumping the counters so the entry's
+    // command_number matches Python (command_count + 1).
+    this.commandHistory.push({
+      command: command.trim(),
+      timestamp: new Date().toISOString(),
+      command_number: this.commandCount + 1,
+      execution_start: Date.now() / 1000,
+    });
+
     const data = command.endsWith("\n") ? command : command + "\n";
     this._inputQueue.push(data);
     this.commandCount++;
+    this.totalCommandsExecuted++;
+    this.lastActivity = new Date();
 
     const waiters = this._inputWaiters.splice(0);
     for (const w of waiters) w();
@@ -168,11 +193,13 @@ export class InteractiveSession {
       }
       const rawOutput = chunks.join("");
       const output = ANSIDecoder.cleanOpenroadOutput(rawOutput);
+      const executionTime = (Date.now() - startTime) / 1000;
+      this._recordReadResult(output.length, executionTime);
       return {
         output,
         sessionId: this.sessionId,
         timestamp: new Date().toISOString(),
-        executionTime: (Date.now() - startTime) / 1000,
+        executionTime,
         commandCount: this.commandCount,
         bufferSize: this.outputBuffer.size,
         error: this._detectErrors(output) ?? null,
@@ -205,6 +232,9 @@ export class InteractiveSession {
     const rawOutput = collected.join("");
     const executionTime = (Date.now() - startTime) / 1000;
     const output = ANSIDecoder.cleanOpenroadOutput(rawOutput);
+
+    await this._updatePerformanceMetrics();
+    this._recordReadResult(output.length, executionTime);
 
     return {
       output,
@@ -323,5 +353,145 @@ export class InteractiveSession {
     }
 
     return undefined;
+  }
+
+  /** Update lastActivity and backfill the last history entry after a read. */
+  private _recordReadResult(outputLength: number, executionTime: number): void {
+    const last = this.commandHistory[this.commandHistory.length - 1];
+    if (last && last.execution_time === undefined) {
+      last.execution_time = executionTime;
+      last.output_length = outputLength;
+    }
+    this.lastActivity = new Date();
+  }
+
+  /** Sample CPU/memory from the live process. Best-effort; silently ignores a
+   * dead or inaccessible PID. CPU time is cumulative (assigned, not summed). */
+  private async _updatePerformanceMetrics(): Promise<void> {
+    const pid = this.pty.pid;
+    if (pid == null) return;
+    try {
+      const usage = await pidusage(pid);
+      this.totalCpuTime = usage.ctime / 1000;
+      const currentMemoryMb = Math.max(0, usage.memory) / BYTES_TO_MB;
+      this.peakMemoryMb = Math.max(this.peakMemoryMb, currentMemoryMb);
+    } catch {
+      // Process may have exited or be inaccessible.
+    }
+  }
+
+  private async _getCurrentMemoryMb(): Promise<number> {
+    const pid = this.pty.pid;
+    if (pid == null) return 0;
+    try {
+      const usage = await pidusage(pid);
+      return Math.max(0, usage.memory) / BYTES_TO_MB;
+    } catch {
+      return 0;
+    }
+  }
+
+  /** True when a configured per-session timeout has been exceeded by uptime.
+   * Distinct from idle timeout - this is wall-clock lifetime, not inactivity. */
+  private _checkSessionTimeout(): boolean {
+    if (this.sessionTimeoutSeconds === null) return false;
+    const uptime = (Date.now() - this.createdAt.getTime()) / 1000;
+    return uptime > this.sessionTimeoutSeconds;
+  }
+
+  async getDetailedMetrics(): Promise<SessionDetailedMetrics> {
+    await this._updatePerformanceMetrics();
+    const now = Date.now();
+    const uptimeSeconds = (now - this.createdAt.getTime()) / 1000;
+    const idleSeconds = (now - this.lastActivity.getTime()) / 1000;
+    const bufferSize = this.outputBuffer.size;
+    const maxSize = this.outputBuffer.maxSize;
+
+    return {
+      session_id: this.sessionId,
+      state: this._state,
+      is_alive: this.isAlive(),
+      created_at: this.createdAt.toISOString(),
+      last_activity: this.lastActivity.toISOString(),
+      uptime_seconds: uptimeSeconds,
+      idle_seconds: idleSeconds,
+      commands: {
+        total_executed: this.totalCommandsExecuted,
+        current_count: this.commandCount,
+        history_length: this.commandHistory.length,
+      },
+      performance: {
+        total_cpu_time: this.totalCpuTime,
+        peak_memory_mb: this.peakMemoryMb,
+        current_memory_mb: await this._getCurrentMemoryMb(),
+      },
+      buffer: {
+        current_size: bufferSize,
+        max_size: maxSize,
+        utilization_percent: maxSize > 0 ? (bufferSize / maxSize) * UTILIZATION_PERCENTAGE_BASE : 0,
+      },
+      timeout: {
+        configured_seconds: this.sessionTimeoutSeconds,
+        is_timed_out: this._checkSessionTimeout(),
+      },
+    };
+  }
+
+  getCommandHistory(limit?: number, search?: string): CommandHistoryEntry[] {
+    let history = [...this.commandHistory];
+
+    if (search) {
+      const needle = search.toLowerCase();
+      history = history.filter((cmd) => cmd.command.toLowerCase().includes(needle));
+    }
+
+    // Sort by timestamp, most recent first.
+    history.sort((a, b) => (a.timestamp < b.timestamp ? 1 : a.timestamp > b.timestamp ? -1 : 0));
+
+    // Match Python's truthy check: limit === 0 leaves the list unsliced.
+    if (limit) {
+      history = history.slice(0, limit);
+    }
+
+    return history;
+  }
+
+  async replayCommand(commandNumber: number): Promise<string> {
+    for (const cmd of this.commandHistory) {
+      if (cmd.command_number === commandNumber) {
+        await this.sendCommand(cmd.command);
+        return cmd.command;
+      }
+    }
+    throw new SessionError(`Command ${commandNumber} not found in history`, this.sessionId);
+  }
+
+  setSessionTimeout(timeoutSeconds: number): void {
+    this.sessionTimeoutSeconds = timeoutSeconds;
+  }
+
+  isIdleTimeout(idleThresholdSeconds: number = this._settings.SESSION_IDLE_TIMEOUT): boolean {
+    const idleTime = (Date.now() - this.lastActivity.getTime()) / 1000;
+    return idleTime > idleThresholdSeconds;
+  }
+
+  async filterOutput(pattern: string, maxLines = 1000): Promise<string[]> {
+    const chunks = await this.outputBuffer.peekAll();
+    if (chunks.length === 0) return [];
+
+    const text = this.outputBuffer.toText(chunks);
+    const lines = text.split("\n");
+
+    let matching: string[];
+    try {
+      const regex = new RegExp(pattern, "i");
+      matching = lines.filter((line) => regex.test(line));
+    } catch {
+      // Fallback to a case-insensitive substring search on invalid regex.
+      const needle = pattern.toLowerCase();
+      matching = lines.filter((line) => line.toLowerCase().includes(needle));
+    }
+
+    return matching.length > 0 ? matching.slice(-maxLines) : [];
   }
 }

--- a/typescript/src/utils/logging.ts
+++ b/typescript/src/utils/logging.ts
@@ -1,0 +1,32 @@
+import pino from "pino";
+import { getSettings } from "../config/settings.js";
+
+/**
+ * Pino-based logging for the MCP server.
+ *
+ * IMPORTANT: all log output goes to stderr (file descriptor 2). stdout is
+ * reserved exclusively for the MCP stdio transport - writing logs there would
+ * corrupt the JSON-RPC protocol stream.
+ *
+ * The root level is initialised from settings (env-driven) at module load so
+ * child loggers created eagerly (e.g. the module-level OpenROADManager
+ * singleton) honour the configured level without depending on setupLogging()
+ * being called first. setupLogging() mutates the root level for loggers created
+ * afterwards; note that pino child loggers capture their level at creation time
+ * and do not dynamically follow the parent.
+ */
+function createRoot(level: string): pino.Logger {
+  return pino({ name: "openroad_mcp", level: level.toLowerCase() }, pino.destination(2));
+}
+
+let rootLogger: pino.Logger = createRoot(getSettings().LOG_LEVEL);
+
+/** Configure the root log level. Call once at startup before heavy logging. */
+export function setupLogging(level: string): void {
+  rootLogger.level = level.toLowerCase();
+}
+
+/** Return a child logger namespaced under `openroad_mcp.<name>`. */
+export function getLogger(name: string): pino.Logger {
+  return rootLogger.child({ module: name });
+}


### PR DESCRIPTION
## Summary

This PR adds the core orchestration layer for the TypeScript port of the OpenROAD MCP server. It builds on the Week 1 PTY work and provides the foundation that the MCP tools will sit on top of in the next stage: command security, the data shapes returned over the wire, per-session metrics, and the session manager that ties everything together.

Up to now the migration had the low-level PTY and session plumbing, but nothing to safely route commands, track sessions, or report their state. Without this layer no MCP tool can be implemented. This PR closes that gap while keeping behavior faithful to the existing Python implementation so the eventual switch is transparent to clients.

## What's included

- **Logging** — a small logger that writes to stderr, keeping stdout reserved for the MCP protocol stream.
- **Command whitelist** — the security model that decides which commands are allowed in read-only vs. state-modifying contexts, ported one-to-one from the Python rules.
- **Result models** — the structured shapes returned to clients, defined so their serialization matches the Python output exactly (including how empty/null values are represented).
- **Session enhancements** — activity tracking, command history, and CPU/memory/idle metrics for each session.
- **Session manager** — a single coordinator for creating, listing, inspecting, and terminating sessions, plus aggregate metrics and idle cleanup.

## Parity & correctness

The implementation deliberately mirrors the Python behaviour, including several subtle edge cases that were verified against the original source and flagged during review (for example, how default values are applied and how command security decisions are made).

## Testing

- Full type checking and linting pass.
- The command whitelist test suite was ported from Python; new tests cover the session manager and the added session metrics/history behaviour.


This PR is intentionally limited to the core layer. The MCP tools and server wiring that expose this functionality to clients come in the next stage.
