### PR TITLE
Feat/ts standalone publish

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -30,6 +30,7 @@ htmlcov/
 # Build artifacts
 build/
 dist/
+node_modules/
 *.egg-info/
 .eggs/
 wheels/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,9 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Set version from tag
+        run: npm version --no-git-tag-version --allow-same-version "${GITHUB_REF_NAME#v}"
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,7 +142,7 @@ jobs:
 
   publish-mcp-registry:
     name: Publish to MCP Registry
-    needs: [publish-pypi, publish-docker]
+    needs: [publish-pypi, publish-npm, publish-docker]
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,44 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
 
+  publish-npm:
+    name: Publish to npm
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # for npm provenance
+    defaults:
+      run:
+        working-directory: typescript
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.4.0
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Typecheck and lint
+        run: |
+          npm run typecheck
+          npm run lint
+
+      - name: Unit tests
+        run: npm run test
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
   github-release:
     name: Create GitHub Release
     needs: build

--- a/.github/workflows/ts-ci.yml
+++ b/.github/workflows/ts-ci.yml
@@ -2,11 +2,11 @@ name: TypeScript CI
 
 on:
   push:
-    branches: [main, "feat/ts-migration**", "feat/ts-integration-tests"]
-    paths: ["typescript/**"]
+    branches: [main, "feat/ts-migration**", "feat/ts-integration-tests", "feat/ts-standalone-publish"]
+    paths: ["typescript/**", "tests/golden/**", "Dockerfile.ts"]
   pull_request:
-    branches: [main, "feat/ts-migration**", "feat/ts-integration-tests"]
-    paths: ["typescript/**"]
+    branches: [main, "feat/ts-migration**", "feat/ts-integration-tests", "feat/ts-standalone-publish"]
+    paths: ["typescript/**", "tests/golden/**", "Dockerfile.ts"]
 
 jobs:
   ts-check:
@@ -27,3 +27,12 @@ jobs:
       - run: npm run test
       - run: npm run test:integration
       - run: npm run test:performance
+
+  ts-docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      # Builds the runtime target, which also runs the in-image entrypoint /
+      # openroad-binary / ORFS-path verification baked into Dockerfile.ts.
+      - name: Build TypeScript runtime image
+        run: docker build -f Dockerfile.ts --target runtime -t openroad-mcp-ts:ci .

--- a/.github/workflows/ts-ci.yml
+++ b/.github/workflows/ts-ci.yml
@@ -2,10 +2,10 @@ name: TypeScript CI
 
 on:
   push:
-    branches: [main, "feat/ts-migration**", "feat/ts-integration-tests", "feat/ts-standalone-publish"]
+    branches: [main, "feat/ts-migration**"]
     paths: ["typescript/**", "tests/golden/**", "Dockerfile.ts"]
   pull_request:
-    branches: [main, "feat/ts-migration**", "feat/ts-integration-tests", "feat/ts-standalone-publish"]
+    branches: [main, "feat/ts-migration**"]
     paths: ["typescript/**", "tests/golden/**", "Dockerfile.ts"]
 
 jobs:

--- a/.github/workflows/ts-ci.yml
+++ b/.github/workflows/ts-ci.yml
@@ -9,6 +9,8 @@ on:
     paths: ["typescript/**", "tests/golden/**", "Dockerfile.ts"]
 
 jobs:
+  # Host-side lint/unit/integration/perf. Does not use the Docker image —
+  # intentional so PR feedback stays fast without pulling openroad/orfs.
   ts-check:
     runs-on: ubuntu-latest
     defaults:
@@ -28,11 +30,17 @@ jobs:
       - run: npm run test:integration
       - run: npm run test:performance
 
+  # Packaging smoke check only: build the runtime image (which runs the
+  # in-Dockerfile entrypoint / openroad / ORFS_FLOW_PATH RUNs) and invoke
+  # --help from the resulting image. Independent of ts-check by design.
+  # Full in-image suites live in Dockerfile.ts `test` stage (local:
+  # docker build -f Dockerfile.ts --target test … && docker run …).
   ts-docker-build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      # Builds the runtime target, which also runs the in-image entrypoint /
-      # openroad-binary / ORFS-path verification baked into Dockerfile.ts.
       - name: Build TypeScript runtime image
-        run: docker build -f Dockerfile.ts --target runtime -t openroad-mcp-ts:ci .
+        run: docker build --progress=plain -f Dockerfile.ts --target runtime -t openroad-mcp-ts:ci .
+      - name: Smoke-run entrypoint from built image
+        run: docker run --rm openroad-mcp-ts:ci --help
+

--- a/.gitignore
+++ b/.gitignore
@@ -205,7 +205,12 @@ __marimo__/
 # Claude
 .claude/settings.local.json
 
-# Project specfics
+# Node / TypeScript
+node_modules/
+coverage/
+*.js.map
+
+# Project specifics
 gcd_final
 gcd_optimization
 gcd_opt_v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- TypeScript/Node.js implementation published to npm, installable via `npx -y openroad-mcp` alongside the existing `uvx` distribution. Requires Node.js 22+.
+- Cross-implementation golden-file schema-parity tests (`tests/golden/`) asserting the TypeScript wire output and tool manifest match the Python contract.
+- Real-OpenROAD REPL integration tests validating completion detection, prompt/ANSI stripping, large-output buffering, and liveness on process exit.
+
+### Fixed
+- TypeScript session info now always serializes `error: null`, matching the Python wire contract.
+
 ## [0.5.5] - 2026-06-09
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.6.0] - 2026-07-14
-
 ### Added
-- TypeScript/Node.js implementation of the MCP server, published to npm and installable via `npx -y openroad-mcp` alongside the existing `uvx` (Python) distribution. Requires Node.js 22+ ([#118](https://github.com/The-OpenROAD-Project/openroad-mcp/pull/118), [#126](https://github.com/The-OpenROAD-Project/openroad-mcp/pull/126), [#127](https://github.com/The-OpenROAD-Project/openroad-mcp/pull/127), [#130](https://github.com/The-OpenROAD-Project/openroad-mcp/pull/130), [#135](https://github.com/The-OpenROAD-Project/openroad-mcp/pull/135)).
-- Dual-publish release pipeline: tagged releases publish to PyPI, npm, GHCR, and the MCP Registry (with an npm package entry in `server.json`).
-- Node/OpenROAD Docker image (`Dockerfile.ts`) for running the TypeScript server with OpenROAD binaries.
-- Cross-implementation golden-file schema-parity and tool-manifest tests (`tests/golden/`) asserting the TypeScript wire output matches the Python contract.
-- TypeScript integration and performance test suites, including real-OpenROAD REPL cases for completion detection, prompt/ANSI stripping, large-output buffering, and liveness on process exit ([#136](https://github.com/The-OpenROAD-Project/openroad-mcp/pull/136)).
-- README and QUICKSTART documentation for the `npx` install path alongside `uvx`.
+- TypeScript/Node.js implementation published to npm, installable via `npx -y openroad-mcp` alongside the existing `uvx` distribution. Requires Node.js 22+.
+- Cross-implementation golden-file schema-parity tests (`tests/golden/`) asserting the TypeScript wire output and tool manifest match the Python contract.
+- Real-OpenROAD REPL integration tests validating completion detection, prompt/ANSI stripping, large-output buffering, and liveness on process exit.
 
 ### Fixed
 - TypeScript session info now always serializes `error: null`, matching the Python wire contract.
-- npm package / advertised MCP server version is derived from the release tag / `package.json` so publishes never ship a stale version.
 
 ## [0.5.5] - 2026-06-09
 
@@ -132,7 +126,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - QUICKSTART guide, ARCHITECTURE, and CONTRIBUTING documentation
 - ROADMAP for planned features
 
-[0.6.0]: https://github.com/The-OpenROAD-Project/openroad-mcp/releases/tag/v0.6.0
 [0.5.5]: https://github.com/The-OpenROAD-Project/openroad-mcp/releases/tag/v0.5.5
 [0.5.4]: https://github.com/The-OpenROAD-Project/openroad-mcp/releases/tag/v0.5.4
 [0.5.3]: https://github.com/The-OpenROAD-Project/openroad-mcp/releases/tag/v0.5.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-07-14
+
 ### Added
-- TypeScript/Node.js implementation published to npm, installable via `npx -y openroad-mcp` alongside the existing `uvx` distribution. Requires Node.js 22+.
-- Cross-implementation golden-file schema-parity tests (`tests/golden/`) asserting the TypeScript wire output and tool manifest match the Python contract.
-- Real-OpenROAD REPL integration tests validating completion detection, prompt/ANSI stripping, large-output buffering, and liveness on process exit.
+- TypeScript/Node.js implementation of the MCP server, published to npm and installable via `npx -y openroad-mcp` alongside the existing `uvx` (Python) distribution. Requires Node.js 22+ ([#118](https://github.com/The-OpenROAD-Project/openroad-mcp/pull/118), [#126](https://github.com/The-OpenROAD-Project/openroad-mcp/pull/126), [#127](https://github.com/The-OpenROAD-Project/openroad-mcp/pull/127), [#130](https://github.com/The-OpenROAD-Project/openroad-mcp/pull/130), [#135](https://github.com/The-OpenROAD-Project/openroad-mcp/pull/135)).
+- Dual-publish release pipeline: tagged releases publish to PyPI, npm, GHCR, and the MCP Registry (with an npm package entry in `server.json`).
+- Node/OpenROAD Docker image (`Dockerfile.ts`) for running the TypeScript server with OpenROAD binaries.
+- Cross-implementation golden-file schema-parity and tool-manifest tests (`tests/golden/`) asserting the TypeScript wire output matches the Python contract.
+- TypeScript integration and performance test suites, including real-OpenROAD REPL cases for completion detection, prompt/ANSI stripping, large-output buffering, and liveness on process exit ([#136](https://github.com/The-OpenROAD-Project/openroad-mcp/pull/136)).
+- README and QUICKSTART documentation for the `npx` install path alongside `uvx`.
 
 ### Fixed
 - TypeScript session info now always serializes `error: null`, matching the Python wire contract.
+- npm package / advertised MCP server version is derived from the release tag / `package.json` so publishes never ship a stale version.
 
 ## [0.5.5] - 2026-06-09
 
@@ -126,6 +132,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - QUICKSTART guide, ARCHITECTURE, and CONTRIBUTING documentation
 - ROADMAP for planned features
 
+[0.6.0]: https://github.com/The-OpenROAD-Project/openroad-mcp/releases/tag/v0.6.0
 [0.5.5]: https://github.com/The-OpenROAD-Project/openroad-mcp/releases/tag/v0.5.5
 [0.5.4]: https://github.com/The-OpenROAD-Project/openroad-mcp/releases/tag/v0.5.4
 [0.5.3]: https://github.com/The-OpenROAD-Project/openroad-mcp/releases/tag/v0.5.3

--- a/Dockerfile.ts
+++ b/Dockerfile.ts
@@ -66,10 +66,11 @@ ENV PATH="/OpenROAD-flow-scripts/tools/install/OpenROAD/bin:/OpenROAD-flow-scrip
     ORFS_FLOW_PATH=/OpenROAD-flow-scripts/flow
 
 # Verify the entrypoint boots, the openroad binary is reachable, and the ORFS
-# flow path exists.
-RUN node /app/dist/main.js --help > /dev/null \
-    && command -v openroad > /dev/null \
-    && test -d "${ORFS_FLOW_PATH}" || (echo "ERROR: ORFS_FLOW_PATH=${ORFS_FLOW_PATH} not found" && exit 1)
+# flow path exists. Each check reports its own cause so a failure isn't
+# misattributed (A && B && C || D would blame D for any of the three).
+RUN node /app/dist/main.js --help > /dev/null || (echo "ERROR: entrypoint 'node dist/main.js --help' failed" && exit 1)
+RUN command -v openroad > /dev/null || (echo "ERROR: openroad binary not found on PATH" && exit 1)
+RUN test -d "${ORFS_FLOW_PATH}" || (echo "ERROR: ORFS_FLOW_PATH=${ORFS_FLOW_PATH} not found" && exit 1)
 
 ENTRYPOINT ["node", "/app/dist/main.js"]
 
@@ -78,6 +79,10 @@ ENTRYPOINT ["node", "/app/dist/main.js"]
 FROM builder AS test
 COPY typescript/vitest.config.ts typescript/vitest.config.integration.ts typescript/vitest.config.performance.ts typescript/eslint.config.ts ./
 COPY typescript/__tests__ ./__tests__
+# Cross-implementation golden fixtures live at <repo>/tests/golden (sibling of
+# typescript/); the golden tests locate them by walking up, so /app/tests/golden
+# is found from /app/__tests__/golden.
+COPY tests/golden ./tests/golden
 ENV PATH="/OpenROAD-flow-scripts/tools/install/OpenROAD/bin:/OpenROAD-flow-scripts/tools/install/yosys/bin:$PATH" \
     ORFS_FLOW_PATH=/OpenROAD-flow-scripts/flow
 CMD ["npm", "run", "test:all"]

--- a/Dockerfile.ts
+++ b/Dockerfile.ts
@@ -70,11 +70,17 @@ ENV PATH="/OpenROAD-flow-scripts/tools/install/OpenROAD/bin:/OpenROAD-flow-scrip
     ORFS_FLOW_PATH=/OpenROAD-flow-scripts/flow
 
 # Verify the entrypoint boots, the openroad binary is reachable, and the ORFS
-# flow path exists. Each check reports its own cause so a failure isn't
-# misattributed (A && B && C || D would blame D for any of the three).
-RUN node /app/dist/main.js --help > /dev/null || (echo "ERROR: entrypoint 'node dist/main.js --help' failed" && exit 1)
-RUN command -v openroad > /dev/null || (echo "ERROR: openroad binary not found on PATH" && exit 1)
-RUN test -d "${ORFS_FLOW_PATH}" || (echo "ERROR: ORFS_FLOW_PATH=${ORFS_FLOW_PATH} not found" && exit 1)
+# flow path exists. Each check is its own RUN so failures are attributed to
+# the right layer. --help exits 0 via commander (see cli.ts); that only ends
+# this RUN layer — later RUNs still execute. Output is left on stdout so
+# `docker build --progress=plain` / CI logs show the help text.
+RUN node /app/dist/main.js --help \
+    && echo "OK: entrypoint --help exited 0"
+RUN command -v openroad \
+    && openroad -version \
+    && echo "OK: openroad on PATH"
+RUN test -d "${ORFS_FLOW_PATH}" \
+    && echo "OK: ORFS_FLOW_PATH=${ORFS_FLOW_PATH}"
 
 ENTRYPOINT ["node", "/app/dist/main.js"]
 

--- a/Dockerfile.ts
+++ b/Dockerfile.ts
@@ -1,0 +1,83 @@
+# TypeScript/Node.js image for the OpenROAD MCP server (npx distribution).
+#
+# Built on openroad/orfs so the OpenROAD binaries the PTY sessions drive are
+# present at runtime — the same reason the Python Dockerfile uses this base.
+# node-pty and sharp need a C++ toolchain during `npm ci`, so the builder
+# installs python3/make/g++; the runtime stage carries only the prebuilt
+# node_modules and compiled dist.
+
+ARG ORFS_VERSION=26Q1-534-g510137693
+ARG NODE_MAJOR=22
+
+# Stage 1: builder — install Node + toolchain, build TypeScript, keep dev deps
+# so the test stage can reuse this image.
+FROM openroad/orfs:${ORFS_VERSION} AS builder
+ARG NODE_MAJOR
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl ca-certificates gnupg python3 make g++ \
+    && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Manifests + postinstall script first so the dependency layer is cached
+# independently of source changes. postinstall runs scripts/fix-node-pty.cjs.
+COPY typescript/package.json typescript/package-lock.json ./
+COPY typescript/scripts ./scripts
+RUN npm ci
+
+COPY typescript/tsconfig.json typescript/tsconfig.test.json ./
+COPY typescript/src ./src
+RUN npm run build
+
+# Stage 2: prod-deps — drop dev dependencies while keeping the already-compiled
+# native modules (node-pty, sharp), so the runtime image stays lean without a
+# toolchain.
+FROM builder AS prod-deps
+RUN npm prune --omit=dev
+
+# Stage 3: runtime
+ARG ORFS_VERSION
+ARG NODE_MAJOR
+FROM openroad/orfs:${ORFS_VERSION} AS runtime
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl ca-certificates gnupg \
+    && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN useradd --create-home --shell /bin/bash --uid 1000 --no-log-init appuser
+
+WORKDIR /app
+
+COPY --from=prod-deps --chown=appuser:appuser /app/node_modules /app/node_modules
+COPY --from=builder --chown=appuser:appuser /app/dist /app/dist
+COPY --chown=appuser:appuser typescript/package.json ./
+
+LABEL io.modelcontextprotocol.server.name="io.github.the-openroad-project/openroad-mcp"
+
+USER appuser
+
+ENV PATH="/OpenROAD-flow-scripts/tools/install/OpenROAD/bin:/OpenROAD-flow-scripts/tools/install/yosys/bin:$PATH" \
+    NODE_ENV=production \
+    ORFS_FLOW_PATH=/OpenROAD-flow-scripts/flow
+
+# Verify the entrypoint boots, the openroad binary is reachable, and the ORFS
+# flow path exists.
+RUN node /app/dist/main.js --help > /dev/null \
+    && command -v openroad > /dev/null \
+    && test -d "${ORFS_FLOW_PATH}" || (echo "ERROR: ORFS_FLOW_PATH=${ORFS_FLOW_PATH} not found" && exit 1)
+
+ENTRYPOINT ["node", "/app/dist/main.js"]
+
+# Stage 4: test — full dev deps + tests, runs unit and real-OpenROAD
+# integration suites against the binaries in this image.
+FROM builder AS test
+COPY typescript/vitest.config.ts typescript/vitest.config.integration.ts typescript/vitest.config.performance.ts typescript/eslint.config.ts ./
+COPY typescript/__tests__ ./__tests__
+ENV PATH="/OpenROAD-flow-scripts/tools/install/OpenROAD/bin:/OpenROAD-flow-scripts/tools/install/yosys/bin:$PATH" \
+    ORFS_FLOW_PATH=/OpenROAD-flow-scripts/flow
+CMD ["npm", "run", "test:all"]

--- a/Dockerfile.ts
+++ b/Dockerfile.ts
@@ -40,14 +40,18 @@ RUN npm prune --omit=dev
 
 # Stage 3: runtime
 ARG ORFS_VERSION
-ARG NODE_MAJOR
 FROM openroad/orfs:${ORFS_VERSION} AS runtime
+ARG NODE_MAJOR
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl ca-certificates gnupg \
     && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
+    
+RUN if ! node --version | grep -qE "^v${NODE_MAJOR}\."; then \
+        echo "ERROR: expected Node ${NODE_MAJOR}, got $(node --version)"; exit 1; \
+    fi
 
 RUN useradd --create-home --shell /bin/bash --uid 1000 --no-log-init appuser
 

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,16 @@ test-performance: docker-test-build
 	@docker run --rm --init $(DOCKER_TEST_IMAGE) uv run pytest tests/performance/
 
 # TypeScript test targets (no Docker required - use bash/cat/echo from host)
+.PHONY: test-ts
+test-ts:
+	@echo "Running TypeScript unit tests..."
+	@cd typescript && npm run test
+
+.PHONY: golden
+golden:
+	@echo "Regenerating cross-implementation golden files..."
+	@uv run python tests/golden/generate_golden.py
+
 .PHONY: test-ts-integration
 test-ts-integration:
 	@echo "Running TypeScript integration tests..."
@@ -109,11 +119,12 @@ inspect:
 
 .PHONY: test-all
 test-all:
-	@echo "Running all tests (core + interactive + tools + integration)..."
+	@echo "Running all tests (python core + interactive + tools + integration, typescript)..."
 	@$(MAKE) test
 	@$(MAKE) test-interactive
 	@$(MAKE) test-tools
 	@$(MAKE) test-integration
+	@$(MAKE) test-ts-all
 
 # Print any Makefile variable: make print-IMAGE_NAME
 print-%:

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -2,6 +2,8 @@
 
 Get up and running with OpenROAD MCP in under 5 minutes! This guide assumes you've already [installed OpenROAD MCP](README.md#installation).
 
+> **Runtime:** OpenROAD MCP ships as two interchangeable distributions — `npx` (needs **Node.js 22+**) or `uvx` (needs **Python 3.13+** and `uv`). Either exposes the same tools; pick whichever runtime you already have. See [Standard Configuration](README.md#standard-configuration).
+
 ## Verify Your Setup
 
 Check that OpenROAD MCP is loaded in your MCP client:

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ behavior. Pick the one that matches your installed runtime.
       "command": "uvx",
       "args": [
         "--from",
-        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0",
+        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5",
         "openroad-mcp"
       ]
     }
@@ -110,8 +110,8 @@ behavior. Pick the one that matches your installed runtime.
 ```
 
 > **Note:** The `uvx` URL above is pinned to a specific release for supply chain safety.
-> To always track the latest version instead, drop the `@v0.6.0` suffix:
-> `"git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0"`.
+> To always track the latest version instead, drop the `@v0.5.5` suffix:
+> `"git+https://github.com/The-OpenROAD-Project/openroad-mcp"`.
 
 > **Every client example below uses `uvx`. To use the npx distribution instead,**
 > swap the `"command"`/`"args"` for the npx block above — the server name, tools,
@@ -177,7 +177,7 @@ Add to `.vscode/mcp.json` (VS Code 1.99+). Note the different schema — `server
       "command": "uvx",
       "args": [
         "--from",
-        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0",
+        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5",
         "openroad-mcp"
       ]
     }
@@ -216,7 +216,7 @@ Add to the Cline MCP settings file:
       "command": "uvx",
       "args": [
         "--from",
-        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0",
+        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5",
         "openroad-mcp"
       ],
       "disabled": false,
@@ -240,7 +240,7 @@ Add to `.roo/mcp.json` in your project root (or the equivalent user-level settin
       "command": "uvx",
       "args": [
         "--from",
-        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0",
+        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5",
         "openroad-mcp"
       ],
       "disabled": false,
@@ -267,7 +267,7 @@ Add to `~/.continue/config.json`:
           "command": "uvx",
           "args": [
             "--from",
-            "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0",
+            "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5",
             "openroad-mcp"
           ]
         }
@@ -292,7 +292,7 @@ Add to `~/.config/zed/settings.json`:
         "path": "uvx",
         "args": [
           "--from",
-          "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0",
+          "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5",
           "openroad-mcp"
         ]
       },
@@ -332,7 +332,7 @@ Add to your VS Code `settings.json` (User or Workspace scope):
         "command": "uvx",
         "args": [
           "--from",
-          "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0",
+          "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5",
           "openroad-mcp"
         ]
       }
@@ -382,7 +382,7 @@ Add to `opencode.json` in your project root:
       "command": [
         "uvx",
         "--from",
-        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0",
+        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5",
         "openroad-mcp"
       ],
       "enabled": true
@@ -412,7 +412,7 @@ Add to `.kilocode/mcp.json` in your project root:
       "command": "uvx",
       "args": [
         "--from",
-        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0",
+        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5",
         "openroad-mcp"
       ],
       "alwaysAllow": [],
@@ -437,7 +437,7 @@ extensions:
     cmd: uvx
     args:
       - --from
-      - git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0
+      - git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5
       - openroad-mcp
     enabled: true
 ```
@@ -459,7 +459,7 @@ Add to your VS Code `settings.json`:
           "command": "uvx",
           "args": [
             "--from",
-            "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0",
+            "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5",
             "openroad-mcp"
           ]
         }
@@ -480,7 +480,7 @@ Add to `~/.codex/config.toml` (global) or `.codex/config.toml` (project-scoped):
 [[mcp_servers]]
 name = "openroad-mcp"
 command = "uvx"
-args = ["--from", "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0", "openroad-mcp"]
+args = ["--from", "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5", "openroad-mcp"]
 ```
 
 </details>
@@ -500,7 +500,7 @@ PearAI uses the same config format as Continue. Add to `~/pearai/config.json`:
           "command": "uvx",
           "args": [
             "--from",
-            "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0",
+            "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5",
             "openroad-mcp"
           ]
         }
@@ -524,7 +524,7 @@ Add to `~/.codebuddy/config.jsonc` (global) or `.codebuddy/mcp.jsonc` (project-s
       "command": "uvx",
       "args": [
         "--from",
-        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0",
+        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5",
         "openroad-mcp"
       ]
     }
@@ -546,7 +546,7 @@ mcp_servers:
     command: uvx
     args:
       - --from
-      - git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0
+      - git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5
       - openroad-mcp
 ```
 
@@ -565,7 +565,7 @@ Add to `~/.copilot/mcp-config.json`:
       "command": "uvx",
       "args": [
         "--from",
-        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0",
+        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5",
         "openroad-mcp"
       ]
     }
@@ -590,7 +590,7 @@ Add to `.omp/mcp.json` (project-level) or `~/.omp/agent/mcp.json` (global):
       "command": "uvx",
       "args": [
         "--from",
-        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0",
+        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5",
         "openroad-mcp"
       ]
     }
@@ -613,7 +613,7 @@ Add to `~/.openclaw/openclaw.json`:
         "command": "uvx",
         "args": [
           "--from",
-          "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0",
+          "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5",
           "openroad-mcp"
         ],
         "enabled": true
@@ -635,7 +635,7 @@ Navigate to the AstrBot WebUI → **MCP** section → **Add Server**, and enter:
 ```json
 {
   "command": "uvx",
-  "args": ["--from", "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0", "openroad-mcp"]
+  "args": ["--from", "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5", "openroad-mcp"]
 }
 ```
 
@@ -657,7 +657,7 @@ Add to `deepcode_config.json` in your project root:
         "command": "uvx",
         "args": [
           "--from",
-          "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0",
+          "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5",
           "openroad-mcp"
         ]
       }
@@ -679,7 +679,7 @@ mcpServers:
     command: uvx
     args:
       - --from
-      - git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0
+      - git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5
       - openroad-mcp
 ```
 
@@ -698,7 +698,7 @@ Add to `.crush.json` (project-local) or `~/.config/crush/crush.json` (global):
       "command": "uvx",
       "args": [
         "--from",
-        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0",
+        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5",
         "openroad-mcp"
       ]
     }
@@ -717,7 +717,7 @@ Add to `reasonix.toml` (project root) or `~/.config/reasonix/config.toml` (globa
 [[plugins]]
 name    = "openroad-mcp"
 command = "uvx"
-args    = ["--from", "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0", "openroad-mcp"]
+args    = ["--from", "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5", "openroad-mcp"]
 ```
 
 Alternatively, use the standard `.mcp.json` format — Reasonix auto-discovers it.

--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ A Model Context Protocol (MCP) server that provides tools for interacting with O
   - [Installation guide](https://openroad.readthedocs.io/en/latest/main/GettingStarted.html)
 - **OpenROAD-flow-scripts (ORFS)** for complete RTL-to-GDS flows (optional but recommended)
   - [ORFS installation guide](https://openroad-flow-scripts.readthedocs.io/)
-- **Python 3.13+** or higher
-- **uv** package manager
-  - Install: `curl -LsSf https://astral.sh/uv/install.sh | sh`
+- **A runtime for one of the two distributions:**
+  - **Node.js 22+** for the `npx` distribution (recommended — no extra install if you already have Node)
+  - **or Python 3.13+ and the `uv` package manager** for the `uvx` distribution
+    - Install uv: `curl -LsSf https://astral.sh/uv/install.sh | sh`
 
 ## Support Matrix
 
@@ -75,7 +76,23 @@ For platform-specific setup instructions, see the [Cross-Platform Guide](docs/CR
 
 ### Standard Configuration
 
-The basic configuration for all MCP clients:
+The server ships as two interchangeable distributions with identical tools and
+behavior. Pick the one that matches your installed runtime.
+
+**npx (Node.js 22+) — recommended:**
+
+```json
+{
+  "mcpServers": {
+    "openroad-mcp": {
+      "command": "npx",
+      "args": ["-y", "openroad-mcp"]
+    }
+  }
+}
+```
+
+**uvx (Python 3.13+ and uv):**
 
 ```json
 {
@@ -92,9 +109,13 @@ The basic configuration for all MCP clients:
 }
 ```
 
-> **Note:** The URL above is pinned to a specific release for supply chain safety.
+> **Note:** The `uvx` URL above is pinned to a specific release for supply chain safety.
 > To always track the latest version instead, drop the `@v0.5.5` suffix:
 > `"git+https://github.com/The-OpenROAD-Project/openroad-mcp"`.
+
+> **Every client example below uses `uvx`. To use the npx distribution instead,**
+> swap the `"command"`/`"args"` for the npx block above — the server name, tools,
+> and behavior are identical.
 
 For local development, use:
 
@@ -713,10 +734,11 @@ Alternatively, use the standard `.mcp.json` format — Reasonix auto-discovers i
 <details>
 <summary><b>MCP Registry</b></summary>
 
-Once published to the [MCP Registry](https://registry.modelcontextprotocol.io), clients can discover and install directly:
+Once published to the [MCP Registry](https://registry.modelcontextprotocol.io), clients can discover and install directly using either distribution:
 
 ```bash
-uvx openroad-mcp
+npx -y openroad-mcp   # Node.js 22+
+uvx openroad-mcp      # Python 3.13+ and uv
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ behavior. Pick the one that matches your installed runtime.
       "command": "uvx",
       "args": [
         "--from",
-        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5",
+        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0",
         "openroad-mcp"
       ]
     }
@@ -110,8 +110,8 @@ behavior. Pick the one that matches your installed runtime.
 ```
 
 > **Note:** The `uvx` URL above is pinned to a specific release for supply chain safety.
-> To always track the latest version instead, drop the `@v0.5.5` suffix:
-> `"git+https://github.com/The-OpenROAD-Project/openroad-mcp"`.
+> To always track the latest version instead, drop the `@v0.6.0` suffix:
+> `"git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0"`.
 
 > **Every client example below uses `uvx`. To use the npx distribution instead,**
 > swap the `"command"`/`"args"` for the npx block above — the server name, tools,
@@ -177,7 +177,7 @@ Add to `.vscode/mcp.json` (VS Code 1.99+). Note the different schema — `server
       "command": "uvx",
       "args": [
         "--from",
-        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5",
+        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0",
         "openroad-mcp"
       ]
     }
@@ -216,7 +216,7 @@ Add to the Cline MCP settings file:
       "command": "uvx",
       "args": [
         "--from",
-        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5",
+        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0",
         "openroad-mcp"
       ],
       "disabled": false,
@@ -240,7 +240,7 @@ Add to `.roo/mcp.json` in your project root (or the equivalent user-level settin
       "command": "uvx",
       "args": [
         "--from",
-        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5",
+        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0",
         "openroad-mcp"
       ],
       "disabled": false,
@@ -267,7 +267,7 @@ Add to `~/.continue/config.json`:
           "command": "uvx",
           "args": [
             "--from",
-            "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5",
+            "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0",
             "openroad-mcp"
           ]
         }
@@ -292,7 +292,7 @@ Add to `~/.config/zed/settings.json`:
         "path": "uvx",
         "args": [
           "--from",
-          "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5",
+          "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0",
           "openroad-mcp"
         ]
       },
@@ -332,7 +332,7 @@ Add to your VS Code `settings.json` (User or Workspace scope):
         "command": "uvx",
         "args": [
           "--from",
-          "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5",
+          "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0",
           "openroad-mcp"
         ]
       }
@@ -382,7 +382,7 @@ Add to `opencode.json` in your project root:
       "command": [
         "uvx",
         "--from",
-        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5",
+        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0",
         "openroad-mcp"
       ],
       "enabled": true
@@ -412,7 +412,7 @@ Add to `.kilocode/mcp.json` in your project root:
       "command": "uvx",
       "args": [
         "--from",
-        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5",
+        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0",
         "openroad-mcp"
       ],
       "alwaysAllow": [],
@@ -437,7 +437,7 @@ extensions:
     cmd: uvx
     args:
       - --from
-      - git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5
+      - git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0
       - openroad-mcp
     enabled: true
 ```
@@ -459,7 +459,7 @@ Add to your VS Code `settings.json`:
           "command": "uvx",
           "args": [
             "--from",
-            "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5",
+            "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0",
             "openroad-mcp"
           ]
         }
@@ -480,7 +480,7 @@ Add to `~/.codex/config.toml` (global) or `.codex/config.toml` (project-scoped):
 [[mcp_servers]]
 name = "openroad-mcp"
 command = "uvx"
-args = ["--from", "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5", "openroad-mcp"]
+args = ["--from", "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0", "openroad-mcp"]
 ```
 
 </details>
@@ -500,7 +500,7 @@ PearAI uses the same config format as Continue. Add to `~/pearai/config.json`:
           "command": "uvx",
           "args": [
             "--from",
-            "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5",
+            "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0",
             "openroad-mcp"
           ]
         }
@@ -524,7 +524,7 @@ Add to `~/.codebuddy/config.jsonc` (global) or `.codebuddy/mcp.jsonc` (project-s
       "command": "uvx",
       "args": [
         "--from",
-        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5",
+        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0",
         "openroad-mcp"
       ]
     }
@@ -546,7 +546,7 @@ mcp_servers:
     command: uvx
     args:
       - --from
-      - git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5
+      - git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0
       - openroad-mcp
 ```
 
@@ -565,7 +565,7 @@ Add to `~/.copilot/mcp-config.json`:
       "command": "uvx",
       "args": [
         "--from",
-        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5",
+        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0",
         "openroad-mcp"
       ]
     }
@@ -590,7 +590,7 @@ Add to `.omp/mcp.json` (project-level) or `~/.omp/agent/mcp.json` (global):
       "command": "uvx",
       "args": [
         "--from",
-        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5",
+        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0",
         "openroad-mcp"
       ]
     }
@@ -613,7 +613,7 @@ Add to `~/.openclaw/openclaw.json`:
         "command": "uvx",
         "args": [
           "--from",
-          "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5",
+          "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0",
           "openroad-mcp"
         ],
         "enabled": true
@@ -635,7 +635,7 @@ Navigate to the AstrBot WebUI → **MCP** section → **Add Server**, and enter:
 ```json
 {
   "command": "uvx",
-  "args": ["--from", "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5", "openroad-mcp"]
+  "args": ["--from", "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0", "openroad-mcp"]
 }
 ```
 
@@ -657,7 +657,7 @@ Add to `deepcode_config.json` in your project root:
         "command": "uvx",
         "args": [
           "--from",
-          "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5",
+          "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0",
           "openroad-mcp"
         ]
       }
@@ -679,7 +679,7 @@ mcpServers:
     command: uvx
     args:
       - --from
-      - git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5
+      - git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0
       - openroad-mcp
 ```
 
@@ -698,7 +698,7 @@ Add to `.crush.json` (project-local) or `~/.config/crush/crush.json` (global):
       "command": "uvx",
       "args": [
         "--from",
-        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5",
+        "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0",
         "openroad-mcp"
       ]
     }
@@ -717,7 +717,7 @@ Add to `reasonix.toml` (project root) or `~/.config/reasonix/config.toml` (globa
 [[plugins]]
 name    = "openroad-mcp"
 command = "uvx"
-args    = ["--from", "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.5.5", "openroad-mcp"]
+args    = ["--from", "git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0", "openroad-mcp"]
 ```
 
 Alternatively, use the standard `.mcp.json` format — Reasonix auto-discovers it.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -205,6 +205,7 @@ The pre-release phase focuses on:
 | v0.5.3 | 2026-06-06 | Expanded agent docs (14+ clients), cross-platform CI, dependency bumps |
 | v0.5.4 | 2026-06-09 | Org migration to The-OpenROAD-Project, urllib3 CVE fix |
 | v0.5.5 | 2026-06-09 | Switch to pypi1 trusted publishing environment |
+| v0.6.0 | 2026-07-14 | TypeScript/npx distribution, dual npm+PyPI publish, golden parity tests |
 | v0.5 | Q2 2026 | Session persistence, e2e testing |
 | v0.8 | Q2 2026 | MCP registry publish, multi-client support, GUI integration |
 | v1.0 | Q2 2026 | API freeze, security audit, production hardening |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -205,7 +205,6 @@ The pre-release phase focuses on:
 | v0.5.3 | 2026-06-06 | Expanded agent docs (14+ clients), cross-platform CI, dependency bumps |
 | v0.5.4 | 2026-06-09 | Org migration to The-OpenROAD-Project, urllib3 CVE fix |
 | v0.5.5 | 2026-06-09 | Switch to pypi1 trusted publishing environment |
-| v0.6.0 | 2026-07-14 | TypeScript/npx distribution, dual npm+PyPI publish, golden parity tests |
 | v0.5 | Q2 2026 | Session persistence, e2e testing |
 | v0.8 | Q2 2026 | MCP registry publish, multi-client support, GUI integration |
 | v1.0 | Q2 2026 | API freeze, security audit, production hardening |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "openroad-mcp"
-version = "0.5.5"
+version = "0.6.0"
 authors = [
     {name = "Precision Innovations", email="it-support@precisioninno.com"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "openroad-mcp"
-version = "0.6.0"
+version = "0.5.5"
 authors = [
     {name = "Precision Innovations", email="it-support@precisioninno.com"},
 ]

--- a/server.json
+++ b/server.json
@@ -9,6 +9,13 @@
   "version": "0.5.5",
   "packages": [
     {
+      "registryType": "npm",
+      "identifier": "openroad-mcp",
+      "version": "0.5.5",
+      "transport": { "type": "stdio" },
+      "runtimeHint": "npx"
+    },
+    {
       "registryType": "pypi",
       "identifier": "openroad-mcp",
       "version": "0.5.5",

--- a/server.json
+++ b/server.json
@@ -6,25 +6,25 @@
     "url": "https://github.com/The-OpenROAD-Project/openroad-mcp",
     "source": "github"
   },
-  "version": "0.6.0",
+  "version": "0.5.5",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "openroad-mcp",
-      "version": "0.6.0",
+      "version": "0.5.5",
       "transport": { "type": "stdio" },
       "runtimeHint": "npx"
     },
     {
       "registryType": "pypi",
       "identifier": "openroad-mcp",
-      "version": "0.6.0",
+      "version": "0.5.5",
       "transport": { "type": "stdio" },
       "runtimeHint": "uvx"
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/the-openroad-project/openroad-mcp:0.6.0",
+      "identifier": "ghcr.io/the-openroad-project/openroad-mcp:0.5.5",
       "transport": { "type": "stdio" },
       "runtimeHint": "docker"
     }

--- a/server.json
+++ b/server.json
@@ -6,25 +6,25 @@
     "url": "https://github.com/The-OpenROAD-Project/openroad-mcp",
     "source": "github"
   },
-  "version": "0.5.5",
+  "version": "0.6.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "openroad-mcp",
-      "version": "0.5.5",
+      "version": "0.6.0",
       "transport": { "type": "stdio" },
       "runtimeHint": "npx"
     },
     {
       "registryType": "pypi",
       "identifier": "openroad-mcp",
-      "version": "0.5.5",
+      "version": "0.6.0",
       "transport": { "type": "stdio" },
       "runtimeHint": "uvx"
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/the-openroad-project/openroad-mcp:0.5.5",
+      "identifier": "ghcr.io/the-openroad-project/openroad-mcp:0.6.0",
       "transport": { "type": "stdio" },
       "runtimeHint": "docker"
     }

--- a/tests/golden/generate_golden.py
+++ b/tests/golden/generate_golden.py
@@ -1,0 +1,247 @@
+"""Generate golden wire-format JSON files from the Python result models.
+
+These golden files are the shared serialization contract between the Python
+(`src/openroad_mcp`) and TypeScript (`typescript/src`) implementations. The
+TypeScript suite reads the same files in
+`typescript/__tests__/golden/schema_parity.test.ts` and asserts its own
+serialization matches, so schema drift (renamed fields, `null` vs missing keys,
+enum-vs-string, nesting changes) fails CI before it can reach an AI client.
+
+The values here are fixed and deterministic on purpose — every field is set
+explicitly (including the ones that default) so the golden captures the full
+wire shape, not just the non-default subset. Live/nondeterministic values
+(timestamps, pids, cpu, memory) are stubbed with fixed sentinels; the parity
+test compares structure and these stubbed values, not real runtime output.
+
+Run from the repo root:
+
+    uv run python tests/golden/generate_golden.py
+
+Regenerate and commit the `tests/golden/*.json` files whenever a result model
+changes on purpose.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from openroad_mcp.core.models import (
+    ImageInfo,
+    ImageMetadata,
+    InteractiveExecResult,
+    InteractiveSessionInfo,
+    InteractiveSessionListResult,
+    ListImagesResult,
+    ReadImageResult,
+    SessionHistoryResult,
+    SessionInspectionResult,
+    SessionMetricsResult,
+    SessionTerminationResult,
+)
+from openroad_mcp.core.models import (
+    SessionState,
+)
+
+GOLDEN_DIR = Path(__file__).parent
+
+# --- Fixed sentinels (kept identical in the TypeScript parity test) ---------
+TS = "2026-01-01T00:00:00"
+SID = "sess-0001"
+
+
+def _detailed_metrics(session_id: str = SID) -> dict:
+    """Structure mirrors InteractiveSession.get_detailed_metrics()."""
+    return {
+        "session_id": session_id,
+        "state": "active",
+        "is_alive": True,
+        "created_at": TS,
+        "last_activity": TS,
+        "uptime_seconds": 12.5,
+        "idle_seconds": 3.25,
+        "commands": {
+            "total_executed": 4,
+            "current_count": 4,
+            "history_length": 4,
+        },
+        "performance": {
+            "total_cpu_time": 1.5,
+            "peak_memory_mb": 128.0,
+            "current_memory_mb": 96.0,
+        },
+        "buffer": {
+            "current_size": 2048,
+            "max_size": 131072,
+            "utilization_percent": 1.5625,
+        },
+        "timeout": {
+            "configured_seconds": 300.0,
+            "is_timed_out": False,
+        },
+    }
+
+
+def _manager_metrics() -> dict:
+    """Structure mirrors OpenROADManager.session_metrics()."""
+    return {
+        "manager": {
+            "total_sessions": 2,
+            "active_sessions": 1,
+            "terminated_sessions": 1,
+            "max_sessions": 10,
+            "utilization_percent": 10.0,
+        },
+        "aggregate": {
+            "total_commands": 4,
+            "total_cpu_time": 1.5,
+            "total_memory_mb": 96.0,
+            "avg_memory_per_session": 96.0,
+        },
+        "sessions": [_detailed_metrics()],
+    }
+
+
+def _history_entry() -> dict:
+    """Structure mirrors the command_history entries in session.py."""
+    return {
+        "command": "place_design",
+        "timestamp": TS,
+        "command_number": 1,
+        "execution_start": 1767225600.0,
+        "execution_time": 0.75,
+        "output_length": 42,
+    }
+
+
+def _cases() -> dict[str, object]:
+    """Every result model that crosses the MCP wire, success + error variants."""
+    active_info = InteractiveSessionInfo(
+        session_id=SID,
+        created_at=TS,
+        is_alive=True,
+        command_count=5,
+        buffer_size=4096,
+        uptime_seconds=12.5,
+        state=SessionState.ACTIVE,
+    )
+    dead_info = InteractiveSessionInfo(
+        session_id="sess-0002",
+        created_at=TS,
+        is_alive=False,
+        command_count=0,
+        buffer_size=0,
+        uptime_seconds=None,
+        state=None,
+        error="Session failed to start",
+    )
+
+    return {
+        # query / exec tools
+        "interactive_exec_result_success": InteractiveExecResult(
+            output="OpenROAD v2.0",
+            session_id=SID,
+            timestamp=TS,
+            execution_time=1.5,
+            command_count=3,
+            buffer_size=2048,
+        ),
+        "interactive_exec_result_error": InteractiveExecResult(
+            output="",
+            session_id=SID,
+            timestamp=TS,
+            execution_time=0.0,
+            command_count=0,
+            buffer_size=0,
+            error="CommandBlocked: 'exit'",
+        ),
+        # create_interactive_session
+        "interactive_session_info_success": active_info,
+        "interactive_session_info_error": dead_info,
+        # list_interactive_sessions
+        "interactive_session_list": InteractiveSessionListResult(
+            sessions=[active_info, dead_info],
+            total_count=2,
+            active_count=1,
+        ),
+        # terminate_interactive_session
+        "session_termination": SessionTerminationResult(
+            session_id=SID,
+            terminated=True,
+            was_alive=True,
+            force=False,
+        ),
+        # inspect_interactive_session
+        "session_inspection": SessionInspectionResult(
+            session_id=SID,
+            metrics=_detailed_metrics(),
+        ),
+        # get_session_history
+        "session_history": SessionHistoryResult(
+            session_id=SID,
+            history=[_history_entry()],
+            total_commands=1,
+            limit=10,
+            search="place",
+        ),
+        # get_session_metrics
+        "session_metrics": SessionMetricsResult(metrics=_manager_metrics()),
+        # list_report_images
+        "list_images": ListImagesResult(
+            run_path="/reports/nangate45/gcd/base",
+            total_images=2,
+            images_by_stage={
+                "floorplan": [
+                    ImageInfo(
+                        filename="floorplan.webp",
+                        path="/reports/nangate45/gcd/base/floorplan.webp",
+                        size_bytes=15000,
+                        modified_time=TS,
+                        type="floorplan",
+                    ),
+                ],
+                "route": [
+                    ImageInfo(
+                        filename="route.webp",
+                        path="/reports/nangate45/gcd/base/route.webp",
+                        size_bytes=22000,
+                        modified_time=TS,
+                        type="route",
+                    ),
+                ],
+            },
+        ),
+        "list_images_empty": ListImagesResult(message="No images found"),
+        # read_report_image
+        "read_image": ReadImageResult(
+            image_data="aGVsbG8=",
+            metadata=ImageMetadata(
+                filename="floorplan.webp",
+                format="webp",
+                size_bytes=15000,
+                width=1024,
+                height=768,
+                modified_time=TS,
+                stage="floorplan",
+                type="floorplan",
+                compression_applied=True,
+                original_size_bytes=48000,
+                original_width=2048,
+                original_height=1536,
+                compression_ratio=0.3125,
+            ),
+        ),
+        "read_image_error": ReadImageResult(error="Image not found: foo.png"),
+    }
+
+
+def main() -> None:
+    for name, model in _cases().items():
+        wire = model.model_dump() if hasattr(model, "model_dump") else model
+        path = GOLDEN_DIR / f"{name}.json"
+        path.write_text(json.dumps(wire, indent=2) + "\n")
+        print(f"wrote {path.relative_to(GOLDEN_DIR.parent.parent)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/golden/generate_golden.py
+++ b/tests/golden/generate_golden.py
@@ -23,6 +23,7 @@ changes on purpose.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
 
@@ -235,12 +236,69 @@ def _cases() -> dict[str, object]:
     }
 
 
+def _canonical_type(prop: dict) -> str | None:
+    """Reduce a JSON-schema property to its base type name.
+
+    Optional params render differently across implementations — Pydantic emits
+    `anyOf: [{type}, {type: null}]`, zod emits a bare `{type}` — so we collapse
+    both to the single non-null base type. Extra keys (min/max/items/default)
+    are incidental and dropped.
+    """
+    if "type" in prop:
+        return prop["type"]
+    if "anyOf" in prop:
+        for branch in prop["anyOf"]:
+            if branch.get("type") != "null":
+                return branch.get("type")
+    return None
+
+
+def _canonical_tool(input_schema: dict, annotations: object) -> dict:
+    props = input_schema.get("properties", {})
+    required = set(input_schema.get("required", []))
+    params = {
+        name: {"type": _canonical_type(prop), "required": name in required}
+        for name, prop in props.items()
+    }
+    hints = None
+    if annotations is not None:
+        hints = {
+            "readOnlyHint": annotations.readOnlyHint,
+            "destructiveHint": annotations.destructiveHint,
+            "idempotentHint": annotations.idempotentHint,
+            "openWorldHint": annotations.openWorldHint,
+        }
+    return {"params": params, "annotations": hints}
+
+
+async def _tool_manifest() -> dict:
+    """Canonical name -> {params, annotations} manifest for all 10 tools.
+
+    The TypeScript suite normalizes its own MCP tools/list output the same way
+    and asserts an exact match, so a renamed param, a flipped required flag, or
+    a changed annotation hint fails CI.
+    """
+    from openroad_mcp.server import mcp
+
+    tools = await mcp.list_tools()
+    manifest = {}
+    for tool in tools:
+        mcp_tool = tool.to_mcp_tool()
+        manifest[mcp_tool.name] = _canonical_tool(mcp_tool.inputSchema, mcp_tool.annotations)
+    return dict(sorted(manifest.items()))
+
+
 def main() -> None:
     for name, model in _cases().items():
         wire = model.model_dump() if hasattr(model, "model_dump") else model
         path = GOLDEN_DIR / f"{name}.json"
         path.write_text(json.dumps(wire, indent=2) + "\n")
         print(f"wrote {path.relative_to(GOLDEN_DIR.parent.parent)}")
+
+    manifest = asyncio.run(_tool_manifest())
+    manifest_path = GOLDEN_DIR / "tool_manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+    print(f"wrote {manifest_path.relative_to(GOLDEN_DIR.parent.parent)}")
 
 
 if __name__ == "__main__":

--- a/tests/golden/interactive_exec_result_error.json
+++ b/tests/golden/interactive_exec_result_error.json
@@ -1,0 +1,9 @@
+{
+  "error": "CommandBlocked: 'exit'",
+  "output": "",
+  "session_id": "sess-0001",
+  "timestamp": "2026-01-01T00:00:00",
+  "execution_time": 0.0,
+  "command_count": 0,
+  "buffer_size": 0
+}

--- a/tests/golden/interactive_exec_result_success.json
+++ b/tests/golden/interactive_exec_result_success.json
@@ -1,0 +1,9 @@
+{
+  "error": null,
+  "output": "OpenROAD v2.0",
+  "session_id": "sess-0001",
+  "timestamp": "2026-01-01T00:00:00",
+  "execution_time": 1.5,
+  "command_count": 3,
+  "buffer_size": 2048
+}

--- a/tests/golden/interactive_session_info_error.json
+++ b/tests/golden/interactive_session_info_error.json
@@ -1,0 +1,10 @@
+{
+  "error": "Session failed to start",
+  "session_id": "sess-0002",
+  "created_at": "2026-01-01T00:00:00",
+  "is_alive": false,
+  "command_count": 0,
+  "buffer_size": 0,
+  "uptime_seconds": null,
+  "state": null
+}

--- a/tests/golden/interactive_session_info_success.json
+++ b/tests/golden/interactive_session_info_success.json
@@ -1,0 +1,10 @@
+{
+  "error": null,
+  "session_id": "sess-0001",
+  "created_at": "2026-01-01T00:00:00",
+  "is_alive": true,
+  "command_count": 5,
+  "buffer_size": 4096,
+  "uptime_seconds": 12.5,
+  "state": "active"
+}

--- a/tests/golden/interactive_session_list.json
+++ b/tests/golden/interactive_session_list.json
@@ -1,0 +1,27 @@
+{
+  "error": null,
+  "sessions": [
+    {
+      "error": null,
+      "session_id": "sess-0001",
+      "created_at": "2026-01-01T00:00:00",
+      "is_alive": true,
+      "command_count": 5,
+      "buffer_size": 4096,
+      "uptime_seconds": 12.5,
+      "state": "active"
+    },
+    {
+      "error": "Session failed to start",
+      "session_id": "sess-0002",
+      "created_at": "2026-01-01T00:00:00",
+      "is_alive": false,
+      "command_count": 0,
+      "buffer_size": 0,
+      "uptime_seconds": null,
+      "state": null
+    }
+  ],
+  "total_count": 2,
+  "active_count": 1
+}

--- a/tests/golden/list_images.json
+++ b/tests/golden/list_images.json
@@ -1,0 +1,26 @@
+{
+  "error": null,
+  "run_path": "/reports/nangate45/gcd/base",
+  "total_images": 2,
+  "images_by_stage": {
+    "floorplan": [
+      {
+        "filename": "floorplan.webp",
+        "path": "/reports/nangate45/gcd/base/floorplan.webp",
+        "size_bytes": 15000,
+        "modified_time": "2026-01-01T00:00:00",
+        "type": "floorplan"
+      }
+    ],
+    "route": [
+      {
+        "filename": "route.webp",
+        "path": "/reports/nangate45/gcd/base/route.webp",
+        "size_bytes": 22000,
+        "modified_time": "2026-01-01T00:00:00",
+        "type": "route"
+      }
+    ]
+  },
+  "message": null
+}

--- a/tests/golden/list_images_empty.json
+++ b/tests/golden/list_images_empty.json
@@ -1,0 +1,7 @@
+{
+  "error": null,
+  "run_path": null,
+  "total_images": null,
+  "images_by_stage": null,
+  "message": "No images found"
+}

--- a/tests/golden/read_image.json
+++ b/tests/golden/read_image.json
@@ -1,0 +1,20 @@
+{
+  "error": null,
+  "image_data": "aGVsbG8=",
+  "metadata": {
+    "filename": "floorplan.webp",
+    "format": "webp",
+    "size_bytes": 15000,
+    "width": 1024,
+    "height": 768,
+    "modified_time": "2026-01-01T00:00:00",
+    "stage": "floorplan",
+    "type": "floorplan",
+    "compression_applied": true,
+    "original_size_bytes": 48000,
+    "original_width": 2048,
+    "original_height": 1536,
+    "compression_ratio": 0.3125
+  },
+  "message": null
+}

--- a/tests/golden/read_image_error.json
+++ b/tests/golden/read_image_error.json
@@ -1,0 +1,6 @@
+{
+  "error": "Image not found: foo.png",
+  "image_data": null,
+  "metadata": null,
+  "message": null
+}

--- a/tests/golden/session_history.json
+++ b/tests/golden/session_history.json
@@ -1,0 +1,17 @@
+{
+  "error": null,
+  "session_id": "sess-0001",
+  "history": [
+    {
+      "command": "place_design",
+      "timestamp": "2026-01-01T00:00:00",
+      "command_number": 1,
+      "execution_start": 1767225600.0,
+      "execution_time": 0.75,
+      "output_length": 42
+    }
+  ],
+  "total_commands": 1,
+  "limit": 10,
+  "search": "place"
+}

--- a/tests/golden/session_inspection.json
+++ b/tests/golden/session_inspection.json
@@ -1,0 +1,32 @@
+{
+  "error": null,
+  "session_id": "sess-0001",
+  "metrics": {
+    "session_id": "sess-0001",
+    "state": "active",
+    "is_alive": true,
+    "created_at": "2026-01-01T00:00:00",
+    "last_activity": "2026-01-01T00:00:00",
+    "uptime_seconds": 12.5,
+    "idle_seconds": 3.25,
+    "commands": {
+      "total_executed": 4,
+      "current_count": 4,
+      "history_length": 4
+    },
+    "performance": {
+      "total_cpu_time": 1.5,
+      "peak_memory_mb": 128.0,
+      "current_memory_mb": 96.0
+    },
+    "buffer": {
+      "current_size": 2048,
+      "max_size": 131072,
+      "utilization_percent": 1.5625
+    },
+    "timeout": {
+      "configured_seconds": 300.0,
+      "is_timed_out": false
+    }
+  }
+}

--- a/tests/golden/session_metrics.json
+++ b/tests/golden/session_metrics.json
@@ -1,0 +1,48 @@
+{
+  "error": null,
+  "metrics": {
+    "manager": {
+      "total_sessions": 2,
+      "active_sessions": 1,
+      "terminated_sessions": 1,
+      "max_sessions": 10,
+      "utilization_percent": 10.0
+    },
+    "aggregate": {
+      "total_commands": 4,
+      "total_cpu_time": 1.5,
+      "total_memory_mb": 96.0,
+      "avg_memory_per_session": 96.0
+    },
+    "sessions": [
+      {
+        "session_id": "sess-0001",
+        "state": "active",
+        "is_alive": true,
+        "created_at": "2026-01-01T00:00:00",
+        "last_activity": "2026-01-01T00:00:00",
+        "uptime_seconds": 12.5,
+        "idle_seconds": 3.25,
+        "commands": {
+          "total_executed": 4,
+          "current_count": 4,
+          "history_length": 4
+        },
+        "performance": {
+          "total_cpu_time": 1.5,
+          "peak_memory_mb": 128.0,
+          "current_memory_mb": 96.0
+        },
+        "buffer": {
+          "current_size": 2048,
+          "max_size": 131072,
+          "utilization_percent": 1.5625
+        },
+        "timeout": {
+          "configured_seconds": 300.0,
+          "is_timed_out": false
+        }
+      }
+    ]
+  }
+}

--- a/tests/golden/session_termination.json
+++ b/tests/golden/session_termination.json
@@ -1,0 +1,7 @@
+{
+  "error": null,
+  "session_id": "sess-0001",
+  "terminated": true,
+  "was_alive": true,
+  "force": false
+}

--- a/tests/golden/tool_manifest.json
+++ b/tests/golden/tool_manifest.json
@@ -1,0 +1,196 @@
+{
+  "create_interactive_session": {
+    "params": {
+      "session_id": {
+        "type": "string",
+        "required": false
+      },
+      "command": {
+        "type": "array",
+        "required": false
+      },
+      "env": {
+        "type": "object",
+        "required": false
+      },
+      "cwd": {
+        "type": "string",
+        "required": false
+      }
+    },
+    "annotations": {
+      "readOnlyHint": false,
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": false
+    }
+  },
+  "get_session_history": {
+    "params": {
+      "session_id": {
+        "type": "string",
+        "required": true
+      },
+      "limit": {
+        "type": "integer",
+        "required": false
+      },
+      "search": {
+        "type": "string",
+        "required": false
+      }
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false
+    }
+  },
+  "get_session_metrics": {
+    "params": {},
+    "annotations": {
+      "readOnlyHint": true,
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false
+    }
+  },
+  "inspect_interactive_session": {
+    "params": {
+      "session_id": {
+        "type": "string",
+        "required": true
+      }
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false
+    }
+  },
+  "interactive_openroad_exec": {
+    "params": {
+      "command": {
+        "type": "string",
+        "required": true
+      },
+      "session_id": {
+        "type": "string",
+        "required": false
+      },
+      "timeout_ms": {
+        "type": "integer",
+        "required": false
+      }
+    },
+    "annotations": {
+      "readOnlyHint": false,
+      "destructiveHint": true,
+      "idempotentHint": false,
+      "openWorldHint": false
+    }
+  },
+  "interactive_openroad_query": {
+    "params": {
+      "command": {
+        "type": "string",
+        "required": true
+      },
+      "session_id": {
+        "type": "string",
+        "required": false
+      },
+      "timeout_ms": {
+        "type": "integer",
+        "required": false
+      }
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": false
+    }
+  },
+  "list_interactive_sessions": {
+    "params": {},
+    "annotations": {
+      "readOnlyHint": true,
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false
+    }
+  },
+  "list_report_images": {
+    "params": {
+      "platform": {
+        "type": "string",
+        "required": true
+      },
+      "design": {
+        "type": "string",
+        "required": true
+      },
+      "run_slug": {
+        "type": "string",
+        "required": true
+      },
+      "stage": {
+        "type": "string",
+        "required": false
+      }
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false
+    }
+  },
+  "read_report_image": {
+    "params": {
+      "platform": {
+        "type": "string",
+        "required": true
+      },
+      "design": {
+        "type": "string",
+        "required": true
+      },
+      "run_slug": {
+        "type": "string",
+        "required": true
+      },
+      "image_name": {
+        "type": "string",
+        "required": true
+      }
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false
+    }
+  },
+  "terminate_interactive_session": {
+    "params": {
+      "session_id": {
+        "type": "string",
+        "required": true
+      },
+      "force": {
+        "type": "boolean",
+        "required": false
+      }
+    },
+    "annotations": {
+      "readOnlyHint": false,
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": false
+    }
+  }
+}

--- a/typescript/.gitignore
+++ b/typescript/.gitignore
@@ -1,4 +1,0 @@
-node_modules/
-dist/
-coverage/
-*.js.map

--- a/typescript/__tests__/golden/golden_dir.ts
+++ b/typescript/__tests__/golden/golden_dir.ts
@@ -1,0 +1,23 @@
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+/**
+ * Locate the committed `tests/golden` fixtures by walking up from this file
+ * until a `tests/golden` directory is found. This avoids a fragile fixed
+ * relative depth: in the source tree the fixtures sit at `<repo>/tests/golden`
+ * (three levels up from `typescript/__tests__/golden`), but inside the Docker
+ * image the `typescript/` layer is collapsed into `/app`, so the depth differs.
+ * Walking up resolves both.
+ */
+export function goldenDir(): string {
+  let dir = path.dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 8; i++) {
+    const candidate = path.join(dir, "tests", "golden");
+    if (existsSync(candidate)) return candidate;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error("could not locate tests/golden fixtures");
+}

--- a/typescript/__tests__/golden/schema_parity.test.ts
+++ b/typescript/__tests__/golden/schema_parity.test.ts
@@ -1,0 +1,237 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { describe, it, expect } from "vitest";
+
+import { toSnakeCase } from "../../src/tools/base.js";
+import {
+  InteractiveSessionListResult,
+  SessionTerminationResult,
+  SessionInspectionResult,
+  SessionHistoryResult,
+  SessionMetricsResult,
+  ListImagesResult,
+  ReadImageResult,
+  type InteractiveExecResult,
+  type InteractiveSessionInfo,
+  type SessionDetailedMetrics,
+  type ManagerMetrics,
+  type CommandHistoryEntry,
+  type ImageInfo,
+  type ImageMetadata,
+  SessionState,
+} from "../../src/core/models.js";
+
+// Cross-implementation schema-parity check.
+//
+// The Python golden files (tests/golden/*.json, produced by
+// generate_golden.py) are the wire-format contract. Here we build the
+// equivalent objects through the SAME TypeScript types and serialize them the
+// SAME way production does (BaseTool.formatResult -> toSnakeCase, plus
+// zod.parse for the schema-backed results), then assert the result matches the
+// golden.
+//
+// Comparison is structural (parse both sides, deep-equal) rather than
+// byte-for-byte: Python and TypeScript legitimately differ on JSON key order
+// (Pydantic emits the BaseResult `error` field first) and float formatting
+// (0.0 vs 0), neither of which is part of the contract. What IS part of the
+// contract — field names after snake_case conversion, null-vs-missing keys,
+// enums-as-strings, defaults, and nesting — is exactly what deep-equal checks.
+
+const GOLDEN_DIR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../../tests/golden",
+);
+
+function golden(name: string): unknown {
+  return JSON.parse(readFileSync(path.join(GOLDEN_DIR, `${name}.json`), "utf8"));
+}
+
+// Fixed sentinels — must stay identical to generate_golden.py.
+const TS = "2026-01-01T00:00:00";
+const SID = "sess-0001";
+
+const detailedMetrics = (sessionId = SID): SessionDetailedMetrics => ({
+  sessionId,
+  state: "active",
+  isAlive: true,
+  createdAt: TS,
+  lastActivity: TS,
+  uptimeSeconds: 12.5,
+  idleSeconds: 3.25,
+  commands: { totalExecuted: 4, currentCount: 4, historyLength: 4 },
+  performance: { totalCpuTime: 1.5, peakMemoryMb: 128.0, currentMemoryMb: 96.0 },
+  buffer: { currentSize: 2048, maxSize: 131072, utilizationPercent: 1.5625 },
+  timeout: { configuredSeconds: 300.0, isTimedOut: false },
+});
+
+const managerMetrics = (): ManagerMetrics => ({
+  manager: {
+    totalSessions: 2,
+    activeSessions: 1,
+    terminatedSessions: 1,
+    maxSessions: 10,
+    utilizationPercent: 10.0,
+  },
+  aggregate: {
+    totalCommands: 4,
+    totalCpuTime: 1.5,
+    totalMemoryMb: 96.0,
+    avgMemoryPerSession: 96.0,
+  },
+  sessions: [detailedMetrics()],
+});
+
+const historyEntry = (): CommandHistoryEntry => ({
+  command: "place_design",
+  timestamp: TS,
+  commandNumber: 1,
+  executionStart: 1767225600.0,
+  executionTime: 0.75,
+  outputLength: 42,
+});
+
+const activeInfo: InteractiveSessionInfo = {
+  sessionId: SID,
+  createdAt: TS,
+  isAlive: true,
+  commandCount: 5,
+  bufferSize: 4096,
+  uptimeSeconds: 12.5,
+  state: SessionState.ACTIVE,
+  error: null,
+};
+
+const deadInfo: InteractiveSessionInfo = {
+  sessionId: "sess-0002",
+  createdAt: TS,
+  isAlive: false,
+  commandCount: 0,
+  bufferSize: 0,
+  uptimeSeconds: null,
+  state: null,
+  error: "Session failed to start",
+};
+
+// Each entry: the production-equivalent serialization, keyed by golden name.
+// `wire()` mirrors BaseTool.formatResult for plain interfaces (toSnakeCase)
+// and the zod-backed tools (parse then toSnakeCase).
+const cases: Record<string, () => unknown> = {
+  interactive_exec_result_success: () => {
+    const r: InteractiveExecResult = {
+      output: "OpenROAD v2.0",
+      sessionId: SID,
+      timestamp: TS,
+      executionTime: 1.5,
+      commandCount: 3,
+      bufferSize: 2048,
+      error: null,
+    };
+    return toSnakeCase(r);
+  },
+  interactive_exec_result_error: () => {
+    const r: InteractiveExecResult = {
+      output: "",
+      sessionId: SID,
+      timestamp: TS,
+      executionTime: 0.0,
+      commandCount: 0,
+      bufferSize: 0,
+      error: "CommandBlocked: 'exit'",
+    };
+    return toSnakeCase(r);
+  },
+  interactive_session_info_success: () => toSnakeCase(activeInfo),
+  interactive_session_info_error: () => toSnakeCase(deadInfo),
+  interactive_session_list: () =>
+    toSnakeCase(
+      InteractiveSessionListResult.parse({
+        sessions: [activeInfo, deadInfo],
+        totalCount: 2,
+        activeCount: 1,
+      }),
+    ),
+  session_termination: () =>
+    toSnakeCase(
+      SessionTerminationResult.parse({
+        sessionId: SID,
+        terminated: true,
+        wasAlive: true,
+        force: false,
+      }),
+    ),
+  session_inspection: () =>
+    toSnakeCase(
+      SessionInspectionResult.parse({
+        sessionId: SID,
+        metrics: detailedMetrics(),
+      }),
+    ),
+  session_history: () =>
+    toSnakeCase(
+      SessionHistoryResult.parse({
+        sessionId: SID,
+        history: [historyEntry()],
+        totalCommands: 1,
+        limit: 10,
+        search: "place",
+      }),
+    ),
+  session_metrics: () =>
+    toSnakeCase(SessionMetricsResult.parse({ metrics: managerMetrics() })),
+  list_images: () => {
+    const floorplan: ImageInfo = {
+      filename: "floorplan.webp",
+      path: "/reports/nangate45/gcd/base/floorplan.webp",
+      sizeBytes: 15000,
+      modifiedTime: TS,
+      type: "floorplan",
+    };
+    const route: ImageInfo = {
+      filename: "route.webp",
+      path: "/reports/nangate45/gcd/base/route.webp",
+      sizeBytes: 22000,
+      modifiedTime: TS,
+      type: "route",
+    };
+    return toSnakeCase(
+      ListImagesResult.parse({
+        runPath: "/reports/nangate45/gcd/base",
+        totalImages: 2,
+        imagesByStage: { floorplan: [floorplan], route: [route] },
+      }),
+    );
+  },
+  list_images_empty: () =>
+    toSnakeCase(ListImagesResult.parse({ message: "No images found" })),
+  read_image: () => {
+    const metadata: ImageMetadata = {
+      filename: "floorplan.webp",
+      format: "webp",
+      sizeBytes: 15000,
+      width: 1024,
+      height: 768,
+      modifiedTime: TS,
+      stage: "floorplan",
+      type: "floorplan",
+      compressionApplied: true,
+      originalSizeBytes: 48000,
+      originalWidth: 2048,
+      originalHeight: 1536,
+      compressionRatio: 0.3125,
+    };
+    return toSnakeCase(
+      ReadImageResult.parse({ imageData: "aGVsbG8=", metadata }),
+    );
+  },
+  read_image_error: () =>
+    toSnakeCase(ReadImageResult.parse({ error: "Image not found: foo.png" })),
+};
+
+describe("schema parity with Python golden files", () => {
+  for (const [name, build] of Object.entries(cases)) {
+    it(`${name} matches the Python wire format`, () => {
+      expect(build()).toEqual(golden(name));
+    });
+  }
+});

--- a/typescript/__tests__/golden/schema_parity.test.ts
+++ b/typescript/__tests__/golden/schema_parity.test.ts
@@ -1,8 +1,8 @@
 import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
 import path from "node:path";
 import { describe, it, expect } from "vitest";
 
+import { goldenDir } from "./golden_dir.js";
 import { toSnakeCase } from "../../src/tools/base.js";
 import {
   InteractiveSessionListResult,
@@ -38,10 +38,7 @@ import {
 // contract — field names after snake_case conversion, null-vs-missing keys,
 // enums-as-strings, defaults, and nesting — is exactly what deep-equal checks.
 
-const GOLDEN_DIR = path.resolve(
-  path.dirname(fileURLToPath(import.meta.url)),
-  "../../../tests/golden",
-);
+const GOLDEN_DIR = goldenDir();
 
 function golden(name: string): unknown {
   return JSON.parse(readFileSync(path.join(GOLDEN_DIR, `${name}.json`), "utf8"));

--- a/typescript/__tests__/golden/tool_manifest.test.ts
+++ b/typescript/__tests__/golden/tool_manifest.test.ts
@@ -1,0 +1,86 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { describe, it, expect, vi } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createMcpServer } from "../../src/server.js";
+import type { OpenROADManager } from "../../src/core/manager.js";
+
+// node-pty must never spawn during a list-tools check.
+vi.mock("node-pty", () => ({ spawn: vi.fn() }));
+
+// Cross-implementation tool-contract check (doc Section 4).
+//
+// tests/golden/tool_manifest.json is generated from the Python FastMCP server
+// (generate_golden.py) and captures, per tool, the canonical param set
+// (name -> {type, required}) and the four annotation hints. Here we boot the
+// TypeScript server, read its own MCP tools/list output, normalize it the same
+// way, and assert an exact match. A renamed param, a flipped required flag, or
+// a changed readOnly/destructive/idempotent hint fails CI.
+//
+// Normalization collapses the incidental schema differences between Pydantic
+// and zod (Pydantic's `anyOf: [{type}, {type: null}]` for optionals vs zod's
+// bare `{type}`, plus zod's min/max/$schema noise) down to the base type name.
+
+const GOLDEN = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../../tests/golden/tool_manifest.json",
+);
+
+type JsonSchema = {
+  properties?: Record<string, { type?: string; anyOf?: { type?: string }[] }>;
+  required?: string[];
+};
+
+function canonicalType(prop: { type?: string; anyOf?: { type?: string }[] }): string | undefined {
+  if (prop.type) return prop.type;
+  if (prop.anyOf) return prop.anyOf.find((b) => b.type !== "null")?.type;
+  return undefined;
+}
+
+function canonicalTool(inputSchema: JsonSchema | undefined, annotations: Record<string, unknown> | undefined): unknown {
+  const props = inputSchema?.properties ?? {};
+  const required = new Set(inputSchema?.required ?? []);
+  const params: Record<string, { type: string | undefined; required: boolean }> = {};
+  for (const [name, prop] of Object.entries(props)) {
+    params[name] = { type: canonicalType(prop), required: required.has(name) };
+  }
+  const a = annotations ?? {};
+  return {
+    params,
+    annotations: {
+      readOnlyHint: a.readOnlyHint ?? null,
+      destructiveHint: a.destructiveHint ?? null,
+      idempotentHint: a.idempotentHint ?? null,
+      openWorldHint: a.openWorldHint ?? null,
+    },
+  };
+}
+
+function makeMockManager(): OpenROADManager {
+  return { listSessions: vi.fn().mockResolvedValue([]) } as unknown as OpenROADManager;
+}
+
+describe("tool-manifest parity with the Python server", () => {
+  it("matches the golden tool manifest", async () => {
+    const server = createMcpServer(makeMockManager());
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    await server.connect(st);
+    const client = new Client({ name: "test-client", version: "0.0.0" });
+    await client.connect(ct);
+
+    const { tools } = await client.listTools();
+    const manifest: Record<string, unknown> = {};
+    for (const t of tools) {
+      manifest[t.name] = canonicalTool(
+        t.inputSchema as JsonSchema | undefined,
+        t.annotations as Record<string, unknown> | undefined,
+      );
+    }
+    await client.close();
+
+    const golden = JSON.parse(readFileSync(GOLDEN, "utf8")) as Record<string, unknown>;
+    expect(manifest).toEqual(golden);
+  });
+});

--- a/typescript/__tests__/golden/tool_manifest.test.ts
+++ b/typescript/__tests__/golden/tool_manifest.test.ts
@@ -1,9 +1,9 @@
 import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
 import path from "node:path";
 import { describe, it, expect, vi } from "vitest";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { goldenDir } from "./golden_dir.js";
 import { createMcpServer } from "../../src/server.js";
 import type { OpenROADManager } from "../../src/core/manager.js";
 
@@ -23,10 +23,7 @@ vi.mock("node-pty", () => ({ spawn: vi.fn() }));
 // and zod (Pydantic's `anyOf: [{type}, {type: null}]` for optionals vs zod's
 // bare `{type}`, plus zod's min/max/$schema noise) down to the base type name.
 
-const GOLDEN = path.resolve(
-  path.dirname(fileURLToPath(import.meta.url)),
-  "../../../tests/golden/tool_manifest.json",
-);
+const GOLDEN = path.join(goldenDir(), "tool_manifest.json");
 
 type JsonSchema = {
   properties?: Record<string, { type?: string; anyOf?: { type?: string }[] }>;

--- a/typescript/__tests__/integration/openroad_repl.test.ts
+++ b/typescript/__tests__/integration/openroad_repl.test.ts
@@ -1,0 +1,136 @@
+import { spawnSync } from "node:child_process";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { OpenROADManager } from "../../src/core/manager.js";
+
+// Real-OpenROAD REPL parity gate (doc Week-1 PTY gate + Risk 1).
+//
+// The other integration tests drive generic PTYs (bash/cat). This suite drives
+// the actual OpenROAD Tcl REPL through the full session stack
+// (OpenROADManager -> InteractiveSession -> node-pty), validating the four
+// known node-pty-vs-Python behavioral hazards:
+//   1. completion detection (100ms silence window), stable across repeats
+//   2. prompt stripping + ANSI cleanup (no "openroad>" / no escape codes)
+//   3. large-output buffering
+//   4. is_alive === false after the process exits
+//
+// It only runs where the `openroad` binary is present (the ORFS Docker image /
+// a local OpenROAD install). Elsewhere it is skipped, so unit CI stays green
+// without OpenROAD.
+
+const ESC = "\x1b";
+
+function hasOpenROAD(): boolean {
+  try {
+    const r = spawnSync("openroad", ["-version"], { timeout: 15000 });
+    return r.status === 0 || (r.stdout != null && r.stdout.length > 0);
+  } catch {
+    return false;
+  }
+}
+
+async function waitUntilAsync(
+  check: () => Promise<boolean>,
+  deadlineMs: number,
+  intervalMs = 100,
+): Promise<boolean> {
+  const deadline = Date.now() + deadlineMs;
+  while (Date.now() < deadline) {
+    if (await check()) return true;
+    await new Promise<void>((r) => setTimeout(r, intervalMs));
+  }
+  return check();
+}
+
+// Drain OpenROAD's (delayed) startup banner so subsequent reads line up with
+// the command that produced them. Neither implementation waits for REPL
+// readiness on spawn (Python's _wait_for_startup_ready is commented out), so
+// the first reads after createSession return the echo before the banner and
+// evaluated output arrive. Assertions below use eval-only markers (e.g. "42"),
+// never the echoed command text, so they can't pass on the echo alone.
+async function warmUp(manager: OpenROADManager, id: string): Promise<void> {
+  for (let i = 0; i < 20; i++) {
+    const r = await manager.executeCommand(id, "puts [expr 21*2]");
+    if (r.output.includes("42")) return;
+  }
+  throw new Error("OpenROAD REPL never became ready");
+}
+
+describe.skipIf(!hasOpenROAD())("OpenROAD REPL integration", () => {
+  let manager: OpenROADManager;
+  let sessionId: string;
+
+  beforeAll(async () => {
+    manager = new OpenROADManager();
+    sessionId = await manager.createSession({});
+    await warmUp(manager, sessionId);
+  }, 60000);
+
+  afterAll(async () => {
+    await manager.cleanupAll();
+  });
+
+  it("completion detection captures evaluated string output", async () => {
+    const result = await manager.executeCommand(sessionId, "puts [string repeat AB 5]");
+    expect(result.error).toBeNull();
+    // "ABABABABAB" appears only in the evaluated output, not the echoed command.
+    expect(result.output).toContain("ABABABABAB");
+    // Prompt stripping + ANSI cleanup: no REPL prompt artifact, no escape codes.
+    expect(result.output).not.toContain("openroad>");
+    expect(result.output).not.toContain(ESC);
+  }, 30000);
+
+  it("evaluates Tcl expressions", async () => {
+    const result = await manager.executeCommand(sessionId, "puts [expr {123 + 456}]");
+    expect(result.error).toBeNull();
+    // "579" is only in the result; the echo contains "123 + 456".
+    expect(result.output).toContain("579");
+  }, 30000);
+
+  it("completion detection is stable across repeated commands", async () => {
+    // Each command must return its OWN evaluated marker on its OWN read — this
+    // is the alignment/stability guarantee. Markers use string-repeat so the
+    // evaluated value (e.g. "YYYYYYY") is never a substring of the echoed
+    // command ("puts [string repeat Y 7]").
+    for (let i = 0; i < 5; i++) {
+      const n = 5 + i;
+      const marker = "Y".repeat(n);
+      const result = await manager.executeCommand(sessionId, `puts [string repeat Y ${n}]`);
+      expect(result.error).toBeNull();
+      expect(result.output).toContain(marker);
+    }
+  }, 60000);
+
+  it("buffers large output without truncation", async () => {
+    const result = await manager.executeCommand(
+      sessionId,
+      "for {set i 0} {$i < 2000} {incr i} { puts [expr {$i + 100000}] }",
+    );
+    expect(result.error).toBeNull();
+    // First and last evaluated values; neither appears in the one-line echo.
+    expect(result.output).toContain("100000");
+    expect(result.output).toContain("101999");
+    expect(result.output.length).toBeGreaterThan(10000);
+  }, 45000);
+
+  it("reports is_alive === false after the process exits", async () => {
+    const exitId = await manager.createSession({});
+    expect((await manager.getSessionInfo(exitId)).isAlive).toBe(true);
+
+    // "exit" ends the OpenROAD process; readOutput may resolve with buffered
+    // output or reject once the process is gone — both are acceptable here.
+    try {
+      await manager.executeCommand(exitId, "exit");
+    } catch {
+      /* process exited mid-read */
+    }
+
+    // getInfo() recomputes liveness via checkAlive(); the session stays mapped
+    // until the next cleanup pass, so this does not throw.
+    const dead = await waitUntilAsync(
+      async () => !(await manager.getSessionInfo(exitId)).isAlive,
+      10000,
+    );
+    expect(dead).toBe(true);
+    expect((await manager.getSessionInfo(exitId)).isAlive).toBe(false);
+  }, 30000);
+});

--- a/typescript/mcp.json.example
+++ b/typescript/mcp.json.example
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "openroad-mcp": {
+      "command": "npx",
+      "args": ["-y", "openroad-mcp"]
+    }
+  }
+}

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openroad-mcp",
-  "version": "0.6.0",
+  "version": "0.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openroad-mcp",
-      "version": "0.6.0",
+      "version": "0.5.5",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openroad-mcp",
-  "version": "0.5.5",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openroad-mcp",
-      "version": "0.5.5",
+      "version": "0.6.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openroad-mcp",
-  "version": "0.5.0",
+  "version": "0.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openroad-mcp",
-      "version": "0.5.0",
+      "version": "0.5.5",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openroad-mcp",
-  "version": "0.5.5",
+  "version": "0.6.0",
   "description": "OpenROAD MCP server (TypeScript/npx)",
   "type": "module",
   "engines": {

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -2,7 +2,13 @@
   "name": "openroad-mcp",
   "version": "0.5.5",
   "description": "OpenROAD MCP server (TypeScript/npx)",
+  "mcpName": "io.github.the-openroad-project/openroad-mcp",
   "type": "module",
+  "license": "BSD-3-Clause",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/The-OpenROAD-Project/openroad-mcp.git"
+  },
   "engines": {
     "node": ">=22"
   },
@@ -10,7 +16,8 @@
     "openroad-mcp": "./dist/main.js"
   },
   "files": [
-    "dist/"
+    "dist/",
+    "scripts/fix-node-pty.cjs"
   ],
   "scripts": {
     "postinstall": "node scripts/fix-node-pty.cjs",
@@ -24,7 +31,6 @@
     "test:all": "npm run test && npm run test:integration && npm run test:performance",
     "dev": "tsx src/main.ts"
   },
-  "license": "BSD-3-Clause",
   "devDependencies": {
     "@types/node": "^25.9.2",
     "@types/pidusage": "^2.0.5",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openroad-mcp",
-  "version": "0.5.0",
+  "version": "0.5.5",
   "description": "OpenROAD MCP server (TypeScript/npx)",
   "type": "module",
   "engines": {

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openroad-mcp",
-  "version": "0.6.0",
+  "version": "0.5.5",
   "description": "OpenROAD MCP server (TypeScript/npx)",
   "type": "module",
   "engines": {

--- a/typescript/src/interactive/session.ts
+++ b/typescript/src/interactive/session.ts
@@ -293,6 +293,10 @@ export class InteractiveSession {
       bufferSize: this.outputBuffer.size,
       uptimeSeconds: uptime,
       state: this._state,
+      // Always present so the wire shape matches Python's model_dump, which
+      // emits error:null for every BaseResult. Omitting it here would drop
+      // the key from the serialized session info (and from list entries).
+      error: null,
     };
   }
 

--- a/typescript/src/server.ts
+++ b/typescript/src/server.ts
@@ -1,5 +1,6 @@
 import { createServer } from "node:http";
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { readFileSync } from "node:fs";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
@@ -23,9 +24,15 @@ import { ListReportImagesTool, ReadReportImageTool } from "./tools/report_images
 
 const logger = getLogger("server");
 
-// Keep in sync with package.json / pyproject.toml. The release workflow rewrites
-// all version strings from the git tag, so this tracks the shared release train.
-const VERSION = "0.5.5";
+// Read from package.json (the single source of truth, rewritten by `npm version`
+// at release time) so the advertised MCP server version never drifts. Both the
+// published npm package and the Docker image ship package.json next to dist/, so
+// ../package.json resolves relative to this compiled module.
+const VERSION = (
+  JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")) as {
+    version: string;
+  }
+).version;
 
 function text(value: string): { content: [{ type: "text"; text: string }] } {
   return { content: [{ type: "text" as const, text: value }] };

--- a/typescript/src/server.ts
+++ b/typescript/src/server.ts
@@ -23,7 +23,9 @@ import { ListReportImagesTool, ReadReportImageTool } from "./tools/report_images
 
 const logger = getLogger("server");
 
-const VERSION = "0.5.0";
+// Keep in sync with package.json / pyproject.toml. The release workflow rewrites
+// all version strings from the git tag, so this tracks the shared release train.
+const VERSION = "0.5.5";
 
 function text(value: string): { content: [{ type: "text"; text: string }] } {
   return { content: [{ type: "text" as const, text: value }] };

--- a/uv.lock
+++ b/uv.lock
@@ -895,7 +895,7 @@ wheels = [
 
 [[package]]
 name = "openroad-mcp"
-version = "0.6.0"
+version = "0.5.5"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/uv.lock
+++ b/uv.lock
@@ -895,7 +895,7 @@ wheels = [
 
 [[package]]
 name = "openroad-mcp"
-version = "0.5.5"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary
Makes the TypeScript server a first-class publishable distribution alongside Python/`uvx`, without cutting a release yet (versions remain `0.5.5`; changelog under `[Unreleased]`).
- **npm publish on tag:** add `publish-npm` to `release.yml` (version from git tag, provenance); wait for it before MCP Registry publish.
- **MCP Registry:** add npm/`npx` package entry in `server.json`.
- **Node + ORFS image:** add `Dockerfile.ts` (builder / runtime / test on `openroad/orfs`); CI builds the runtime target only (no GHCR push for TS yet).
- **Cross-impl contract:** Python golden generator + fixtures under `tests/golden/`; TS schema-parity and tool-manifest tests.
- **Real OpenROAD REPL integration:** completion detection, prompt/ANSI stripping, large output, `isAlive` after exit (skipped if `openroad` missing).
- **Docs:** README / QUICKSTART / `mcp.json.example` for `npx -y openroad-mcp`.
- **CI / make:** wire TS into `test-all`; expand `ts-ci` path filters (`typescript/**`, `tests/golden/**`, `Dockerfile.ts`); simplify branch filter to `main` + `feat/ts-migration**`.
- **Hygiene:** root `.gitignore` for `node_modules/` / coverage / sourcemaps; advertised version read from `package.json` at release time.
**Out of scope:** no `0.6.0` version bump / official release (use Prepare Release from `main` later).