### PR TITLE
fix(deps): upgrade mcp to 1.28.1 to fix 3 high-severity CVEs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "fastmcp==3.2.0",
-    "mcp[cli]==1.26.0",
+    "mcp[cli]==1.28.1",
     "pillow==12.2.0",
     "psutil==7.2.2",
     "pydantic==2.12.5",

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,12 @@
 version = 1
 revision = 3
 requires-python = ">=3.13"
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and sys_platform != 'win32'",
+]
 
 [[package]]
 name = "aiofile"
@@ -790,7 +796,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.26.0"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -808,9 +814,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615, upload-time = "2026-01-24T19:40:30.652Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [package.optional-dependencies]
@@ -931,7 +937,7 @@ dev = [
 requires-dist = [
     { name = "fastmcp", specifier = "==3.2.0" },
     { name = "google-genai", marker = "extra == 'dev'", specifier = "==1.69.0" },
-    { name = "mcp", extras = ["cli"], specifier = "==1.26.0" },
+    { name = "mcp", extras = ["cli"], specifier = "==1.28.1" },
     { name = "mypy", marker = "extra == 'dev'", specifier = "==1.20.0" },
     { name = "pillow", specifier = "==12.2.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = "==4.5.1" },
@@ -1560,8 +1566,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
## Summary

Bumps `mcp[cli]` from `1.26.0` to `1.28.1`, resolving all open Dependabot alerts.

| # | Severity | Advisory | Fixed in |
|---|----------|----------|----------|
| #141 | high | WebSocket server transport does not support Host/Origin validation | 1.28.1 |
| #140 | high | HTTP transports serve session requests without verifying the authenticated principal | 1.27.2 |
| #139 | high | Experimental task handlers allow any client to access/cancel other clients' tasks | 1.27.2 |

Compatible with `fastmcp==3.2.0` (requires `mcp<2.0,>=1.24.0`).

## Testing

- `uv lock` / `uv sync --extra dev` resolve cleanly (`mcp 1.26.0 → 1.28.1`)
- `mcp` and `fastmcp` import OK
- Full test suite passes (316 passed); the 15 failing `tests/performance/*` are pre-existing and require the `openroad` binary (absent in CI/local sandbox), unrelated to this change

Closes #141, closes #140, closes #139.