### PR TITLE
fix(ci): use existing GH_PAT secret for prepare-release and auto-tag

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -218,7 +218,7 @@ merge, squash, or tag.
 
 > **Tagging is automated.** When @vvbandeira squash-merges the release PR, the
 > `auto-tag.yml` workflow detects the `chore: release vX.Y.Z` commit message and
-> pushes the tag as `openroad-ci` using `OPENROAD_CI_PAT`. This ensures the
+> pushes the tag as `openroad-ci` using `GH_PAT`. This ensures the
 > release workflow actor is a publicly visible org member, satisfying the MCP
 > Registry OIDC check. No manual tagging needed.
 
@@ -226,9 +226,10 @@ merge, squash, or tag.
 
 - **Never push to `main` directly.** Always use a `release/vX.Y.Z` branch and open a PR.
 - **@vvbandeira must review and merge** — request them as a reviewer on every release PR.
-- **`OPENROAD_CI_PAT` secret required** — this PAT must be stored in the repo settings
-  with `Contents: Read and write` scope. The `auto-tag.yml` workflow uses it to push
-  the release tag as `openroad-ci`, satisfying the MCP Registry org-membership check.
+- **`GH_PAT` secret required** — this PAT must be stored in the repo settings
+  with `Contents: Read and write` scope (and Pull requests write for Prepare Release).
+  The `auto-tag.yml` / `prepare-release.yml` workflows use it to push the release
+  branch/tag as `openroad-ci`, satisfying the MCP Registry org-membership check.
 - Always use `uv lock` to regenerate the lockfile rather than editing it manually
 - The CHANGELOG date format is ISO: `YYYY-MM-DD`
 - Version tags use a `v` prefix: `v0.4.0` (but the version in files has no prefix)

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          token: ${{ secrets.OPENROAD_CI_PAT }}
+          token: ${{ secrets.GH_PAT }}
 
       - name: Extract version
         id: version

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          token: ${{ secrets.OPENROAD_CI_PAT }}
+          token: ${{ secrets.GH_PAT }}
           fetch-depth: 0
 
       - name: Install uv
@@ -196,7 +196,7 @@ jobs:
 
       - name: Open release PR
         env:
-          GH_TOKEN: ${{ secrets.OPENROAD_CI_PAT }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
           TAG="${{ steps.version.outputs.tag }}"
           BRANCH="${{ steps.version.outputs.branch }}"


### PR DESCRIPTION
OPENROAD_CI_PAT is not configured in repo secrets; GH_PAT already is. Point both workflows at GH_PAT so Prepare Release can checkout, push the release branch, and open the PR.