### PR TITLE
Chore/deprecate python distribution

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,12 +1,8 @@
 {
   "mcpServers": {
     "openroad-mcp": {
-      "command": "uvx",
-      "args": [
-        "--from",
-        "git+https://github.com/The-OpenROAD-Project/openroad-mcp",
-        "openroad-mcp"
-      ]
+      "command": "npx",
+      "args": ["-y", "openroad-mcp"]
     }
   }
 }

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,11 +1,8 @@
 {
   "mcpServers": {
     "openroad-mcp": {
-      "command": "uv",
-      "args": [
-        "run",
-        "openroad-mcp"
-      ]
+      "command": "npx",
+      "args": ["-y", "openroad-mcp"]
     }
   },
   "privacy": {

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,17 +1,8 @@
 {
   "mcpServers": {
     "openroad-mcp": {
-      "command": "uv",
-      "args": [
-        "run",
-        "--project",
-        "python",
-        "openroad-mcp"
-      ],
-      "env": {
-        "OPENROAD_EXE": "/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad",
-        "OPENROAD_FLOW": "/OpenROAD-flow-scripts/flow"
-      }
+      "command": "npx",
+      "args": ["-y", "openroad-mcp"]
     }
   }
 }

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -2,7 +2,7 @@
 
 Get up and running with OpenROAD MCP in under 5 minutes! This guide assumes you've already [installed OpenROAD MCP](README.md#installation).
 
-> **Runtime:** OpenROAD MCP ships as two interchangeable distributions — `npx` (needs **Node.js 22+**) or `uvx` (needs **Python 3.13+** and `uv`). Either exposes the same tools; pick whichever runtime you already have. See [Standard Configuration](README.md#standard-configuration).
+> **Runtime:** OpenROAD MCP ships as two interchangeable distributions — `npx` (needs **Node.js 22+**, recommended) or `uvx` (needs **Python 3.13+** and `uv`, **deprecated** — final PyPI release, no further updates). Both expose the same tools; use `npx` unless you have a reason to stick with `uvx`. See [Standard Configuration](README.md#standard-configuration).
 
 ## Verify Your Setup
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ behavior. Pick the one that matches your installed runtime.
 > To always track the latest version instead, drop the `@v0.5.5` suffix:
 > `"git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0#subdirectory=python"`.
 
-> **The `uvx` distribution below is deprecated** (final release — no
+> **The `uvx` distribution above is deprecated** (final release — no
 > further PyPI publishes). **Every client example below still uses `uvx`
 > for now; swap the `"command"`/`"args"` for the `npx` block above** to
 > use the actively maintained npm distribution instead — the server name,

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ A Model Context Protocol (MCP) server that provides tools for interacting with O
   - [ORFS installation guide](https://openroad-flow-scripts.readthedocs.io/)
 - **A runtime for one of the two distributions:**
   - **Node.js 22+** for the `npx` distribution (recommended — no extra install if you already have Node)
-  - **or Python 3.13+ and the `uv` package manager** for the `uvx` distribution
+  - **or Python 3.13+ and the `uv` package manager** for the `uvx`
+    distribution (deprecated — final release, see below)
     - Install uv: `curl -LsSf https://astral.sh/uv/install.sh | sh`
 
 ## Support Matrix
@@ -92,7 +93,7 @@ behavior. Pick the one that matches your installed runtime.
 }
 ```
 
-**uvx (Python 3.13+ and uv):**
+**uvx (Python 3.13+ and uv) — deprecated, final release:**
 
 ```json
 {
@@ -113,9 +114,11 @@ behavior. Pick the one that matches your installed runtime.
 > To always track the latest version instead, drop the `@v0.5.5` suffix:
 > `"git+https://github.com/The-OpenROAD-Project/openroad-mcp@v0.6.0#subdirectory=python"`.
 
-> **Every client example below uses `uvx`. To use the npx distribution instead,**
-> swap the `"command"`/`"args"` for the npx block above — the server name, tools,
-> and behavior are identical.
+> **The `uvx` distribution below is deprecated** (final release — no
+> further PyPI publishes). **Every client example below still uses `uvx`
+> for now; swap the `"command"`/`"args"` for the `npx` block above** to
+> use the actively maintained npm distribution instead — the server name,
+> tools, and behavior are identical.
 
 For local development, use:
 

--- a/python/README.md
+++ b/python/README.md
@@ -3,7 +3,8 @@
 > **Deprecated.** This Python/PyPI distribution is no longer maintained and
 > this is its final release. Please switch to the npm distribution:
 > `npx -y openroad-mcp`. See the
-> [main project README](../README.md) for setup instructions.
+> [main project README](https://github.com/The-OpenROAD-Project/openroad-mcp/blob/main/README.md)
+> for setup instructions.
 
 A Model Context Protocol (MCP) server that provides tools for interacting with
 OpenROAD and ORFS (OpenROAD Flow Scripts).

--- a/python/README.md
+++ b/python/README.md
@@ -1,5 +1,10 @@
 # OpenROAD MCP Server (Python distribution)
 
+> **Deprecated.** This Python/PyPI distribution is no longer maintained and
+> this is its final release. Please switch to the npm distribution:
+> `npx -y openroad-mcp`. See the
+> [main project README](../README.md) for setup instructions.
+
 A Model Context Protocol (MCP) server that provides tools for interacting with
 OpenROAD and ORFS (OpenROAD Flow Scripts).
 
@@ -20,7 +25,7 @@ architecture docs, see the [main project README](../README.md) and the
 - **Python 3.13+** and the [`uv`](https://astral.sh/uv) package manager
   - Install uv: `curl -LsSf https://astral.sh/uv/install.sh | sh`
 
-## Configuration (uvx)
+## Configuration (uvx) — deprecated
 
 ```json
 {

--- a/python/src/openroad_mcp/main.py
+++ b/python/src/openroad_mcp/main.py
@@ -11,6 +11,13 @@ from openroad_mcp.utils.logging import setup_logging
 
 def main() -> None:
     """Main application entry point."""
+    print(
+        "openroad-mcp: the Python/PyPI distribution is deprecated and will not "
+        "receive further releases. Switch to the npm distribution: "
+        "npx -y openroad-mcp. See "
+        "https://github.com/The-OpenROAD-Project/openroad-mcp/blob/main/README.md",
+        file=sys.stderr,
+    )
     try:
         # Parse command line arguments
         config = parse_cli_args()


### PR DESCRIPTION
**Summary**

Print an unconditional deprecation notice to stderr on every Python server start (python/src/openroad_mcp/main.py), so anyone still on uvx sees the migration path regardless of log level.

Switch this repo's own local MCP client configs (.mcp.json, .claude/settings.json, .gemini/settings.json) to npx -y openroad-mcp, matching typescript/mcp.json.example; drop .mcp.json's OPENROAD_EXE/OPENROAD_FLOW env vars, confirmed dead (unreferenced in either python/src or typescript/src).

Add a deprecation banner to python/README.md — this is what PyPI renders as the package's long description — stating it's the final release and pointing to npx -y openroad-mcp, with an absolute GitHub URL so the link resolves correctly off pypi.org (no relative-path rewriting available; pyproject.toml has no [project.urls]).

Mark the uvx distribution deprecated in README.md and QUICKSTART.md while keeping every existing uvx config block/example fully functional — this is still a working final release, not a removal.

**Why**

The TypeScript/npm distribution is now the actively maintained one. Rather than silently dropping the Python package, we're shipping one last PyPI release that clearly tells existing uvx users to move to npx — via a runtime warning, docs, and PyPI's own long description — without breaking anyone still on it.
