### PR TITLE
Chore/v1.0 cleanup test improvements

### DIFF
--- a/.github/actions/ts-checks/action.yml
+++ b/.github/actions/ts-checks/action.yml
@@ -1,0 +1,30 @@
+name: TypeScript checks
+description: >
+  Install Node, run npm ci, then the shared gate: npm audit, typecheck, lint.
+  Callers checkout the repo themselves first and add their own test steps
+  after this action, since those diverge per workflow.
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.4.0
+      with:
+        node-version: "22"
+        cache: "npm"
+        cache-dependency-path: typescript/package-lock.json
+
+    - run: npm ci
+      shell: bash
+      working-directory: typescript
+
+    - run: npm run audit
+      shell: bash
+      working-directory: typescript
+
+    - run: npm run typecheck
+      shell: bash
+      working-directory: typescript
+
+    - run: npm run lint
+      shell: bash
+      working-directory: typescript

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -32,13 +32,31 @@ jobs:
           cache: "npm"
           cache-dependency-path: typescript/package-lock.json
 
-      - name: Install dependencies
-        run: npm ci
+      # The scripts cd into typescript/ themselves and run npm ci + npm run
+      # build, so they must run from the repo root, not the job's typescript/
+      # default. Node is already on PATH from setup-node above; the scripts
+      # detect that and skip reinstalling it.
+      - name: Run Ubuntu setup script
+        if: runner.os == 'Linux'
+        working-directory: .
+        run: bash scripts/setup-ubuntu.sh
 
-      - name: Build
-        run: npm run build
+      - name: Run macOS setup script
+        if: runner.os == 'macOS'
+        working-directory: .
+        run: bash scripts/setup-macos.sh
 
       - name: Smoke-test entrypoint
         # Exercises node-pty and sharp native module loading — this is the
         # check that actually matters for cross-platform compatibility.
         run: node dist/main.js --help
+
+      - name: Run unit tests
+        run: npm run test
+
+      - name: Run integration tests
+        # pty_integration.test.ts runs unconditionally (generic bash/echo/cat
+        # processes, no OpenROAD needed). openroad_repl.test.ts self-skips via
+        # describe.skipIf when openroad isn't on PATH, which none of these
+        # runners have — it reports skipped, not failed.
+        run: npm run test:integration

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    - cron: "0 3 * * 0"
 
 env:
   CI: "true"

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -1,0 +1,19 @@
+name: Docker Test Stage (real OpenROAD)
+
+on:
+  workflow_call:
+
+jobs:
+  docker-test:
+    name: Docker test stage (real OpenROAD)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Build test image
+        # --target test pulls openroad/orfs as the base so OpenROAD binaries
+        # are available; npm run test:all runs unit + integration + performance.
+        run: docker build --progress=plain -f Dockerfile --target test -t openroad-mcp-test:ci .
+
+      - name: Run full test suite inside image
+        run: docker run --rm openroad-mcp-test:ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Audit dependencies
+        run: npm run audit
+
       - name: Typecheck and lint
         run: |
           npm run typecheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,23 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Set up Node.js
-        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.4.0
-        with:
-          node-version: "22"
-          cache: "npm"
-          cache-dependency-path: typescript/package-lock.json
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Audit dependencies
-        run: npm run audit
-
-      - name: Typecheck and lint
-        run: |
-          npm run typecheck
-          npm run lint
+      - uses: ./.github/actions/ts-checks
 
       - name: Run tests
         run: npm run test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,9 +38,13 @@ jobs:
       - name: Run tests
         run: npm run test
 
+  docker-test:
+    name: Docker test stage (real OpenROAD)
+    uses: ./.github/workflows/docker-test.yml
+
   publish-npm:
     name: Publish to npm
-    needs: test
+    needs: [test, docker-test]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -83,7 +87,7 @@ jobs:
 
   github-release:
     name: Create GitHub Release
-    needs: test
+    needs: [test, docker-test]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -106,7 +110,7 @@ jobs:
 
   publish-docker:
     name: Publish Docker image
-    needs: test
+    needs: [test, docker-test]
     uses: ./.github/workflows/docker-publish.yml
     with:
       image_tag: ${{ github.ref_name }}

--- a/.github/workflows/ts-ci.yml
+++ b/.github/workflows/ts-ci.yml
@@ -63,6 +63,7 @@ jobs:
         run: docker run --rm openroad-mcp-ts:ci --help
 
   ts-docker-test:
+    name: Docker test stage (real OpenROAD)
     uses: ./.github/workflows/docker-test.yml
 
   ts-perf:

--- a/.github/workflows/ts-ci.yml
+++ b/.github/workflows/ts-ci.yml
@@ -61,18 +61,7 @@ jobs:
         run: docker run --rm openroad-mcp-ts:ci --help
 
   ts-docker-test:
-    name: Docker test stage (real OpenROAD)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Build test image
-        # --target test pulls openroad/orfs as the base so OpenROAD binaries
-        # are available; npm run test:all runs unit + integration + performance.
-        run: docker build --progress=plain -f Dockerfile --target test -t openroad-mcp-test:ci .
-
-      - name: Run full test suite inside image
-        run: docker run --rm openroad-mcp-test:ci
+    uses: ./.github/workflows/docker-test.yml
 
   ts-perf:
     name: Performance benchmarks (nightly)

--- a/.github/workflows/ts-ci.yml
+++ b/.github/workflows/ts-ci.yml
@@ -27,6 +27,8 @@ jobs:
 
       - run: npm ci
 
+      - run: npm run audit
+
       - run: npm run typecheck
 
       - run: npm run lint

--- a/.github/workflows/ts-ci.yml
+++ b/.github/workflows/ts-ci.yml
@@ -19,19 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.4.0
-        with:
-          node-version: "22"
-          cache: "npm"
-          cache-dependency-path: typescript/package-lock.json
-
-      - run: npm ci
-
-      - run: npm run audit
-
-      - run: npm run typecheck
-
-      - run: npm run lint
+      - uses: ./.github/actions/ts-checks
 
       - run: npm run test:coverage
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,10 +52,14 @@ Run these individually during development and together before opening a PR:
 
 ```bash
 npm run test             # Unit tests (fast, no OpenROAD required)
-npm run test:integration # Integration tests (require OpenROAD on PATH)
+npm run test:integration # Integration tests
 npm run test:performance # Performance / memory benchmarks
 npm run test:all         # Run everything
 ```
+
+*(`test:integration` runs two suites: generic-PTY tests that need no OpenROAD install,
+and an OpenROAD-REPL suite that self-skips — reports skipped, not failed — when
+`openroad` isn't on `PATH`. Only the latter actually requires OpenROAD.)*
 
 *(Tests use [vitest](https://vitest.dev/). Configuration is in `typescript/vitest.config.ts`.)*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,4 +93,12 @@ COPY typescript/__tests__ ./__tests__
 # output) and are already present from the COPY above — no separate copy needed.
 ENV PATH="/OpenROAD-flow-scripts/tools/install/OpenROAD/bin:/OpenROAD-flow-scripts/tools/install/yosys/bin:$PATH" \
     ORFS_FLOW_PATH=/OpenROAD-flow-scripts/flow
+
+# Fail the build loudly if openroad isn't reachable here, rather than letting
+# openroad_repl.test.ts's hasOpenROAD() check silently skip the real-OpenROAD
+# suite and have npm run test:all exit 0 without it having run.
+RUN command -v openroad \
+    && openroad -version \
+    && echo "OK: openroad on PATH"
+
 CMD ["npm", "run", "test:all"]

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -7,21 +7,25 @@ set -euo pipefail
 echo "🔧 Setting up OpenROAD-MCP on macOS..."
 
 if [[ -z "${CI:-}" ]]; then
-    read -r -p "This script will install uv and project dependencies. Continue? [y/N] " response
+    read -r -p "This script will install Node.js and project dependencies. Continue? [y/N] " response
     if [[ ! "$response" =~ ^[Yy]$ ]]; then
         echo "Aborted."
         exit 0
     fi
 fi
 
-if ! command -v uv &>/dev/null; then
-    echo "📦 Installing uv..."
-    curl -LsSf https://astral.sh/uv/install.sh | sh
-    export PATH="$HOME/.local/bin:$PATH"
+if ! command -v node &>/dev/null || ! node --version | grep -qE "^v22\."; then
+    if ! command -v brew &>/dev/null; then
+        echo "Homebrew is required to install Node.js. Install it from https://brew.sh and re-run this script." >&2
+        exit 1
+    fi
+    echo "📦 Installing Node.js 22..."
+    brew install node@22
+    export PATH="$(brew --prefix node@22)/bin:$PATH"
 fi
 
 echo "📦 Installing project dependencies..."
-(cd python && uv sync --all-extras --inexact)
+(cd typescript && npm ci && npm run build)
 
 echo ""
 echo "✅ macOS setup complete!"

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -4,7 +4,7 @@
 # =============================================================================
 set -euo pipefail
 
-echo "🔧 Setting up OpenROAD-MCP on macOS..."
+echo "Setting up OpenROAD-MCP on macOS..."
 
 if [[ -z "${CI:-}" ]]; then
     read -r -p "This script will install Node.js and project dependencies. Continue? [y/N] " response
@@ -19,16 +19,16 @@ if ! command -v node &>/dev/null || ! node --version | grep -qE "^v22\."; then
         echo "Homebrew is required to install Node.js. Install it from https://brew.sh and re-run this script." >&2
         exit 1
     fi
-    echo "📦 Installing Node.js 22..."
+    echo "Installing Node.js 22..."
     brew install node@22
     export PATH="$(brew --prefix node@22)/bin:$PATH"
 fi
 
-echo "📦 Installing project dependencies..."
+echo "Installing project dependencies..."
 (cd typescript && npm ci && npm run build)
 
 echo ""
-echo "✅ macOS setup complete!"
+echo "macOS setup complete."
 echo ""
 echo "Next steps:"
 echo "  1. Install OpenROAD (optional, for full flows):"

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -14,7 +14,15 @@ if [[ -z "${CI:-}" ]]; then
     fi
 fi
 
-if ! command -v node &>/dev/null || ! node --version | grep -qE "^v22\."; then
+node_major=0
+if command -v node &>/dev/null; then
+    node_major="$(node --version | sed -E 's/^v([0-9]+).*/\1/')"
+    [[ "$node_major" =~ ^[0-9]+$ ]] || node_major=0
+fi
+
+# package.json declares "node": ">=22" — any major >= 22 already satisfies it,
+# not only exactly 22.
+if [ "$node_major" -lt 22 ]; then
     if ! command -v brew &>/dev/null; then
         echo "Homebrew is required to install Node.js. Install it from https://brew.sh and re-run this script." >&2
         exit 1

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -4,7 +4,7 @@
 # =============================================================================
 set -euo pipefail
 
-echo "🔧 Setting up OpenROAD-MCP on Ubuntu..."
+echo "Setting up OpenROAD-MCP on Ubuntu..."
 
 if [[ -z "${CI:-}" ]]; then
     read -r -p "This script will install system packages and project dependencies. Continue? [y/N] " response
@@ -20,16 +20,16 @@ sudo apt-get install -y --no-install-recommends \
     curl ca-certificates gnupg build-essential
 
 if ! command -v node &>/dev/null || ! node --version | grep -qE "^v22\."; then
-    echo "📦 Installing Node.js 22..."
+    echo "Installing Node.js 22..."
     curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
     sudo apt-get install -y --no-install-recommends nodejs
 fi
 
-echo "📦 Installing project dependencies..."
+echo "Installing project dependencies..."
 (cd typescript && npm ci && npm run build)
 
 echo ""
-echo "✅ Ubuntu setup complete!"
+echo "Ubuntu setup complete."
 echo ""
 echo "Next steps:"
 echo "  1. Install OpenROAD: https://openroad.readthedocs.io/en/latest/main/GettingStarted.html"

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -19,7 +19,15 @@ sudo apt-get update
 sudo apt-get install -y --no-install-recommends \
     curl ca-certificates gnupg build-essential
 
-if ! command -v node &>/dev/null || ! node --version | grep -qE "^v22\."; then
+node_major=0
+if command -v node &>/dev/null; then
+    node_major="$(node --version | sed -E 's/^v([0-9]+).*/\1/')"
+    [[ "$node_major" =~ ^[0-9]+$ ]] || node_major=0
+fi
+
+# package.json declares "node": ">=22" — any major >= 22 already satisfies it,
+# not only exactly 22.
+if [ "$node_major" -lt 22 ]; then
     echo "Installing Node.js 22..."
     curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
     sudo apt-get install -y --no-install-recommends nodejs

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -14,19 +14,19 @@ if [[ -z "${CI:-}" ]]; then
     fi
 fi
 
+# build-essential is needed for node-pty and sharp's native addon builds.
 sudo apt-get update
-sudo apt-get install -y \
-    python3 python3-dev \
-    build-essential curl
+sudo apt-get install -y --no-install-recommends \
+    curl ca-certificates gnupg build-essential
 
-if ! command -v uv &>/dev/null; then
-    echo "📦 Installing uv..."
-    curl -LsSf https://astral.sh/uv/install.sh | sh
-    export PATH="$HOME/.local/bin:$PATH"
+if ! command -v node &>/dev/null || ! node --version | grep -qE "^v22\."; then
+    echo "📦 Installing Node.js 22..."
+    curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
+    sudo apt-get install -y --no-install-recommends nodejs
 fi
 
 echo "📦 Installing project dependencies..."
-(cd python && uv sync --all-extras --inexact)
+(cd typescript && npm ci && npm run build)
 
 echo ""
 echo "✅ Ubuntu setup complete!"
@@ -34,4 +34,4 @@ echo ""
 echo "Next steps:"
 echo "  1. Install OpenROAD: https://openroad.readthedocs.io/en/latest/main/GettingStarted.html"
 echo "  2. Run tests:        make test"
-echo "  3. Start MCP server: uv run --project python openroad-mcp"
+echo "  3. Start MCP server: npx -y openroad-mcp"

--- a/typescript/__tests__/core/manager.test.ts
+++ b/typescript/__tests__/core/manager.test.ts
@@ -16,6 +16,7 @@ vi.mock("../../src/interactive/session.js", () => {
 interface MockSession {
   sessionId: string;
   lastActivity: Date;
+  terminatedAt: Date | null;
   checkAlive: Mock;
   start: Mock;
   sendCommand: Mock;
@@ -23,6 +24,8 @@ interface MockSession {
   getInfo: Mock;
   getDetailedMetrics: Mock;
   getCommandHistory: Mock;
+  replayCommand: Mock;
+  filterOutput: Mock;
   isIdleTimeout: Mock;
   setSessionTimeout: Mock;
   terminate: Mock;
@@ -47,6 +50,7 @@ function makeMockSession(sessionId: string, alive = true): MockSession {
   return {
     sessionId,
     lastActivity: new Date(),
+    terminatedAt: null,
     checkAlive: vi.fn().mockReturnValue(alive),
     start: vi.fn().mockResolvedValue(undefined),
     sendCommand: vi.fn().mockResolvedValue(undefined),
@@ -70,6 +74,8 @@ function makeMockSession(sessionId: string, alive = true): MockSession {
     }),
     getDetailedMetrics: vi.fn().mockResolvedValue(metrics),
     getCommandHistory: vi.fn().mockReturnValue([]),
+    replayCommand: vi.fn().mockResolvedValue("replayed output"),
+    filterOutput: vi.fn().mockResolvedValue(["matched line"]),
     isIdleTimeout: vi.fn().mockReturnValue(false),
     setSessionTimeout: vi.fn(),
     terminate: vi.fn().mockResolvedValue(undefined),
@@ -262,6 +268,166 @@ describe("OpenROADManager", () => {
   describe("_getSession behaviour via public methods", () => {
     it("getSessionInfo throws SessionNotFoundError for an unknown id", async () => {
       await expect(manager.getSessionInfo("ghost")).rejects.toBeInstanceOf(SessionNotFoundError);
+    });
+
+    it("throws SessionError when the session is still being created", async () => {
+      MockedSession.mockImplementationOnce(function (this: unknown, sessionId: string) {
+        const mock = makeMockSession(sessionId);
+        mock.start.mockReturnValue(new Promise<void>(() => {})); // never resolves
+        created.push(mock);
+        return mock as unknown as InteractiveSession;
+      } as unknown as (sessionId: string) => InteractiveSession);
+      void manager.createSession({ sessionId: "pending" });
+      // Flush microtasks so createSession's exclusive callback runs far enough
+      // to set the null placeholder before start()'s never-resolving promise
+      // parks it — cleanupLock.runExclusive and _cleanupTerminatedSessions
+      // each add an await hop.
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      await expect(manager.executeCommand("pending", "version")).rejects.toThrow(/still being created/);
+    });
+  });
+
+  describe("replayCommand, filterSessionOutput, setSessionTimeout", () => {
+    it("replayCommand delegates to the session", async () => {
+      await manager.createSession({ sessionId: "s1" });
+      const output = await manager.replayCommand("s1", 3);
+      expect(created[0]!.replayCommand).toHaveBeenCalledWith(3);
+      expect(output).toBe("replayed output");
+    });
+
+    it("filterSessionOutput delegates to the session with the maxLines default", async () => {
+      await manager.createSession({ sessionId: "s1" });
+      const lines = await manager.filterSessionOutput("s1", "ERROR");
+      expect(created[0]!.filterOutput).toHaveBeenCalledWith("ERROR", 1000);
+      expect(lines).toEqual(["matched line"]);
+    });
+
+    it("setSessionTimeout delegates to the session", async () => {
+      await manager.createSession({ sessionId: "s1" });
+      await manager.setSessionTimeout("s1", 120);
+      expect(created[0]!.setSessionTimeout).toHaveBeenCalledWith(120);
+    });
+  });
+
+  describe("createSession bufferSize forwarding", () => {
+    it("forwards an explicit positive bufferSize as-is", async () => {
+      await manager.createSession({ sessionId: "s1", bufferSize: 4096 });
+      expect(MockedSession).toHaveBeenCalledWith("s1", 4096);
+    });
+  });
+
+  describe("executeCommand timeout forwarding", () => {
+    it("forwards an explicit positive timeoutMs as-is", async () => {
+      await manager.createSession({ sessionId: "s1" });
+      await manager.executeCommand("s1", "report_wns", 5000);
+      expect(created[0]!.readOutput).toHaveBeenCalledWith(5000);
+    });
+  });
+
+  describe("listSessions error handling", () => {
+    it("skips a session whose getInfo() rejects and still returns the rest", async () => {
+      await manager.createSession({ sessionId: "s1" });
+      await manager.createSession({ sessionId: "s2" });
+      created[0]!.getInfo.mockRejectedValueOnce(new Error("boom"));
+
+      const infos = await manager.listSessions();
+      expect(infos.map((i) => i.sessionId)).toEqual(["s2"]);
+    });
+  });
+
+  describe("sessionMetrics edge cases", () => {
+    it("skips a session whose getDetailedMetrics() rejects and still aggregates the rest", async () => {
+      await manager.createSession({ sessionId: "s1" });
+      await manager.createSession({ sessionId: "s2" });
+      created[0]!.getDetailedMetrics.mockRejectedValueOnce(new Error("boom"));
+
+      const metrics = await manager.sessionMetrics();
+      expect(metrics.sessions).toHaveLength(1);
+      expect(metrics.sessions[0]!.sessionId).toBe("s2");
+    });
+
+    it("reports zero utilization when maxSessions is 0", async () => {
+      const zeroCapacity = new OpenROADManager(0);
+      const metrics = await zeroCapacity.sessionMetrics();
+      expect(metrics.manager.utilizationPercent).toBe(0);
+    });
+
+    it("reports zero average memory when there are no active sessions", async () => {
+      const metrics = await manager.sessionMetrics();
+      expect(metrics.aggregate.avgMemoryPerSession).toBe(0);
+    });
+  });
+
+  describe("cleanupIdleSessions error handling", () => {
+    it("logs and continues when isIdleTimeout() throws for one session", async () => {
+      await manager.createSession({ sessionId: "s1" });
+      await manager.createSession({ sessionId: "s2" });
+      created[0]!.isIdleTimeout.mockImplementationOnce(() => {
+        throw new Error("boom");
+      });
+      created[1]!.isIdleTimeout.mockReturnValue(true);
+
+      const cleaned = await manager.cleanupIdleSessions(300, true);
+      expect(cleaned).toBe(1);
+      expect(manager.getSessionCount()).toBe(1);
+    });
+  });
+
+  describe("cleanupAll", () => {
+    it("force-terminates every session", async () => {
+      await manager.createSession({ sessionId: "s1" });
+      await manager.cleanupAll();
+      expect(created[0]!.terminate).toHaveBeenCalledWith(true);
+      expect(manager.getSessionCount()).toBe(0);
+    });
+  });
+
+  describe("_cleanupTerminatedSessions via listSessions", () => {
+    it("cleans up a recently-dead session without force", async () => {
+      await manager.createSession({ sessionId: "s1" });
+      created[0]!.checkAlive.mockReturnValue(false);
+      created[0]!.lastActivity = new Date();
+
+      const infos = await manager.listSessions();
+      expect(infos).toHaveLength(0);
+      expect(created[0]!.cleanup).toHaveBeenCalledOnce();
+      expect(manager.getSessionCount()).toBe(0);
+    });
+
+    it("force-cleans a session dead long past the grace period, keyed off terminatedAt", async () => {
+      await manager.createSession({ sessionId: "s1" });
+      created[0]!.checkAlive.mockReturnValue(false);
+      created[0]!.terminatedAt = new Date(Date.now() - 120_000); // 120s > 60s threshold
+
+      const infos = await manager.listSessions();
+      expect(infos).toHaveLength(0);
+      expect(created[0]!.cleanup).toHaveBeenCalledOnce();
+      expect(manager.getSessionCount()).toBe(0);
+    });
+
+    it("still removes the session if a non-force cleanup() rejects", async () => {
+      await manager.createSession({ sessionId: "s1" });
+      created[0]!.checkAlive.mockReturnValue(false);
+      created[0]!.lastActivity = new Date();
+      created[0]!.cleanup.mockRejectedValueOnce(new Error("cleanup boom"));
+
+      const infos = await manager.listSessions();
+      expect(infos).toHaveLength(0);
+      expect(manager.getSessionCount()).toBe(0);
+    });
+
+    it("still removes the session if a force cleanup() rejects", async () => {
+      await manager.createSession({ sessionId: "s1" });
+      created[0]!.checkAlive.mockReturnValue(false);
+      created[0]!.terminatedAt = new Date(Date.now() - 120_000);
+      created[0]!.cleanup.mockRejectedValueOnce(new Error("force cleanup boom"));
+
+      const infos = await manager.listSessions();
+      expect(infos).toHaveLength(0);
+      expect(manager.getSessionCount()).toBe(0);
     });
   });
 });

--- a/typescript/__tests__/tools/report_images.test.ts
+++ b/typescript/__tests__/tools/report_images.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import sharp from "sharp";
 import {
   classifyImageType,
   ListReportImagesTool,
@@ -65,6 +66,16 @@ function createFixture(
 
 // Constructor requires a manager but the tools never invoke it.
 const stubManager = {} as unknown as OpenROADManager;
+
+/** Writes a real, sharp-parseable .webp file so metadata()/resize() succeed. */
+async function writeRealWebp(filePath: string, width: number, height: number): Promise<void> {
+  const buffer = await sharp({
+    create: { width, height, channels: 3, background: { r: 100, g: 150, b: 200 } },
+  })
+    .webp()
+    .toBuffer();
+  fs.writeFileSync(filePath, buffer);
+}
 
 beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openroad-test-"));
@@ -427,5 +438,258 @@ describe("TestPlatformDesignValidationInTools", () => {
   it("read tool returns error for invalid design", async () => {
     const raw = await new ReadReportImageTool(stubManager).execute("nangate45", "bad_design", "run-123", "img.webp");
     expect(JSON.parse(raw).error).toBeTruthy();
+  });
+});
+
+describe("ListReportImagesTool — additional branch coverage", () => {
+  it("falls back to an empty available-runs list when readdirSync fails while listing runs", async () => {
+    // reportsBase must exist (so realpathSync/containment checks pass) but the
+    // requested run must not — that's the only way availableRuns()'s readdirSync
+    // catch (returning []) is reachable rather than short-circuiting earlier.
+    const { flowPath, runPath } = createFixture();
+    const reportsBase = path.dirname(runPath);
+    (getSettings as ReturnType<typeof vi.fn>).mockReturnValue({
+      platforms: ["nangate45"],
+      designs: (p: string) => (p === "nangate45" ? ["gcd"] : []),
+      flowPath,
+      WHITELIST_ENABLED: false,
+    });
+    const originalReaddirSync = fs.readdirSync.bind(fs);
+    const readdirSpy = vi.spyOn(fs, "readdirSync").mockImplementation(((p: fs.PathLike, opts?: unknown) => {
+      if (p === reportsBase) throw new Error("EACCES: permission denied");
+      return originalReaddirSync(p as string, opts as never);
+    }) as typeof fs.readdirSync);
+    try {
+      const raw = await new ListReportImagesTool(stubManager).execute("nangate45", "gcd", "nonexistent-run");
+      const result = JSON.parse(raw);
+      expect(result.error).toBe("RunNotFound");
+      expect(result.message).toContain("none");
+    } finally {
+      readdirSpy.mockRestore();
+    }
+  });
+
+  it("descends into real subdirectories to find nested .webp files", async () => {
+    const { flowPath, runPath } = createFixture("nangate45", "gcd", "run-123", ["final_all.webp"]);
+    const nested = path.join(runPath, "nested_stage");
+    fs.mkdirSync(nested, { recursive: true });
+    fs.writeFileSync(path.join(nested, "cts_clk.webp"), Buffer.from("RIFF\x00\x00\x00\x00WEBP"));
+    (getSettings as ReturnType<typeof vi.fn>).mockReturnValue({
+      platforms: ["nangate45"],
+      designs: (p: string) => (p === "nangate45" ? ["gcd"] : []),
+      flowPath,
+      WHITELIST_ENABLED: false,
+    });
+    const raw = await new ListReportImagesTool(stubManager).execute("nangate45", "gcd", "run-123");
+    const result = JSON.parse(raw);
+    expect(result.total_images).toBe(2);
+  });
+
+  it("sorts multiple images within the same stage bucket", async () => {
+    const { flowPath } = createFixture("nangate45", "gcd", "run-123", [
+      "cts_clk.webp",
+      "cts_clk_layout.webp",
+      "cts_core_clock.webp",
+    ]);
+    (getSettings as ReturnType<typeof vi.fn>).mockReturnValue({
+      platforms: ["nangate45"],
+      designs: (p: string) => (p === "nangate45" ? ["gcd"] : []),
+      flowPath,
+      WHITELIST_ENABLED: false,
+    });
+    const raw = await new ListReportImagesTool(stubManager).execute("nangate45", "gcd", "run-123");
+    const result = JSON.parse(raw);
+    const filenames: string[] = result.images_by_stage.cts.map((i: { filename: string }) => i.filename);
+    expect(filenames).toHaveLength(3);
+    // Assert against localeCompare's own ordering rather than a hardcoded
+    // guess — punctuation-vs-letter collation is locale-dependent.
+    expect(filenames).toEqual([...filenames].sort((a, b) => a.localeCompare(b)));
+  });
+
+  it("returns UnexpectedError when resolveRunPath fails for a non-validation reason", async () => {
+    (getSettings as ReturnType<typeof vi.fn>).mockReturnValue({
+      platforms: ["nangate45"],
+      designs: () => {
+        throw new Error("settings backend unavailable");
+      },
+      flowPath: tmpDir,
+      WHITELIST_ENABLED: false,
+    });
+    const raw = await new ListReportImagesTool(stubManager).execute("nangate45", "gcd", "run-123");
+    const result = JSON.parse(raw);
+    expect(result.error).toBe("UnexpectedError");
+  });
+
+  it("returns an empty list (not an error) when findWebpFiles throws inside an existing run dir", async () => {
+    const { flowPath, runPath } = createFixture();
+    (getSettings as ReturnType<typeof vi.fn>).mockReturnValue({
+      platforms: ["nangate45"],
+      designs: (p: string) => (p === "nangate45" ? ["gcd"] : []),
+      flowPath,
+      WHITELIST_ENABLED: false,
+    });
+    const originalReaddirSync = fs.readdirSync.bind(fs);
+    vi.spyOn(fs, "readdirSync").mockImplementation(((p: fs.PathLike, opts?: unknown) => {
+      if (p === runPath) throw new Error("EACCES: permission denied");
+      return originalReaddirSync(p as string, opts as never);
+    }) as typeof fs.readdirSync);
+
+    const raw = await new ListReportImagesTool(stubManager).execute("nangate45", "gcd", "run-123");
+    const result = JSON.parse(raw);
+    expect(result.total_images).toBe(0);
+    vi.restoreAllMocks();
+  });
+
+  it("returns UnexpectedError when a later filesystem call fails unexpectedly", async () => {
+    const { flowPath, runPath } = createFixture("nangate45", "gcd", "run-123", ["cts_clk.webp"]);
+    (getSettings as ReturnType<typeof vi.fn>).mockReturnValue({
+      platforms: ["nangate45"],
+      designs: (p: string) => (p === "nangate45" ? ["gcd"] : []),
+      flowPath,
+      WHITELIST_ENABLED: false,
+    });
+    const targetFile = path.join(runPath, "cts_clk.webp");
+    const originalStatSync = fs.statSync.bind(fs);
+    const statSpy = vi.spyOn(fs, "statSync").mockImplementation((p) => {
+      if (p === targetFile) throw new Error("boom");
+      return originalStatSync(p) as fs.Stats;
+    });
+    const raw = await new ListReportImagesTool(stubManager).execute("nangate45", "gcd", "run-123");
+    const result = JSON.parse(raw);
+    expect(result.error).toBe("UnexpectedError");
+    statSpy.mockRestore();
+  });
+});
+
+describe("ReadReportImageTool — additional branch coverage", () => {
+  it("returns UnexpectedError when resolveRunPath fails for a non-validation reason", async () => {
+    (getSettings as ReturnType<typeof vi.fn>).mockReturnValue({
+      platforms: ["nangate45"],
+      designs: () => {
+        throw new Error("settings backend unavailable");
+      },
+      flowPath: tmpDir,
+      WHITELIST_ENABLED: false,
+    });
+    const raw = await new ReadReportImageTool(stubManager).execute("nangate45", "gcd", "run-123", "cts_clk.webp");
+    const result = JSON.parse(raw);
+    expect(result.error).toBe("UnexpectedError");
+  });
+
+  it("returns NotAFile when the requested name is a directory", async () => {
+    const { flowPath, runPath } = createFixture("nangate45", "gcd", "run-123", []);
+    fs.mkdirSync(path.join(runPath, "dir.webp"));
+    (getSettings as ReturnType<typeof vi.fn>).mockReturnValue({
+      platforms: ["nangate45"],
+      designs: (p: string) => (p === "nangate45" ? ["gcd"] : []),
+      flowPath,
+      WHITELIST_ENABLED: false,
+    });
+    const raw = await new ReadReportImageTool(stubManager).execute("nangate45", "gcd", "run-123", "dir.webp");
+    const result = JSON.parse(raw);
+    expect(result.error).toBe("NotAFile");
+  });
+
+  it("falls back to an empty available-images list when findWebpFiles throws for ImageNotFound", async () => {
+    const { flowPath, runPath } = createFixture("nangate45", "gcd", "run-123", ["cts_clk.webp"]);
+    (getSettings as ReturnType<typeof vi.fn>).mockReturnValue({
+      platforms: ["nangate45"],
+      designs: (p: string) => (p === "nangate45" ? ["gcd"] : []),
+      flowPath,
+      WHITELIST_ENABLED: false,
+    });
+    const originalReaddirSync = fs.readdirSync.bind(fs);
+    vi.spyOn(fs, "readdirSync").mockImplementation(((p: fs.PathLike, opts?: unknown) => {
+      if (p === runPath) throw new Error("EACCES: permission denied");
+      return originalReaddirSync(p as string, opts as never);
+    }) as typeof fs.readdirSync);
+
+    const raw = await new ReadReportImageTool(stubManager).execute("nangate45", "gcd", "run-123", "missing.webp");
+    const result = JSON.parse(raw);
+    expect(result.error).toBe("ImageNotFound");
+    expect(result.message).toContain("none");
+    vi.restoreAllMocks();
+  });
+
+  it("reads a small real .webp image without compression and reports its real dimensions", async () => {
+    const { flowPath, runPath } = createFixture("nangate45", "gcd", "run-123", []);
+    await writeRealWebp(path.join(runPath, "cts_clk.webp"), 4, 4);
+    (getSettings as ReturnType<typeof vi.fn>).mockReturnValue({
+      platforms: ["nangate45"],
+      designs: (p: string) => (p === "nangate45" ? ["gcd"] : []),
+      flowPath,
+      WHITELIST_ENABLED: false,
+    });
+    const raw = await new ReadReportImageTool(stubManager).execute("nangate45", "gcd", "run-123", "cts_clk.webp");
+    const result = JSON.parse(raw);
+    expect(result.error).toBeNull();
+    expect(result.metadata.width).toBe(4);
+    expect(result.metadata.height).toBe(4);
+    expect(result.metadata.compression_applied).toBe(false);
+    expect(result.metadata.compression_ratio).toBeNull();
+  });
+
+  it("compresses a large real image and reports a compression ratio", async () => {
+    const { flowPath, runPath } = createFixture("nangate45", "gcd", "run-123", []);
+    // 200x200 solid-color webp comfortably exceeds the 15KB base64 threshold
+    // once raw, forcing the resize/compress branch.
+    await writeRealWebp(path.join(runPath, "final_all.webp"), 200, 200);
+    (getSettings as ReturnType<typeof vi.fn>).mockReturnValue({
+      platforms: ["nangate45"],
+      designs: (p: string) => (p === "nangate45" ? ["gcd"] : []),
+      flowPath,
+      WHITELIST_ENABLED: false,
+    });
+    const originalStatSync = fs.statSync.bind(fs);
+    const imagePath = path.join(runPath, "final_all.webp");
+    const statSpy = vi.spyOn(fs, "statSync").mockImplementation((p) => {
+      const real = originalStatSync(p) as fs.Stats;
+      if (p === imagePath) {
+        // Mutate in place (not a spread copy) so prototype methods like
+        // isFile() survive; force the compression branch regardless of how
+        // small sharp's synthetic webp actually compresses to.
+        Object.defineProperty(real, "size", { value: 20 * 1024, configurable: true });
+      }
+      return real;
+    });
+    try {
+      const raw = await new ReadReportImageTool(stubManager).execute("nangate45", "gcd", "run-123", "final_all.webp");
+      const result = JSON.parse(raw);
+      expect(result.error).toBeNull();
+      expect(result.metadata.compression_applied).toBe(true);
+      expect(result.metadata.compression_ratio).toBeGreaterThan(0);
+      expect(result.metadata.original_size_bytes).toBeGreaterThan(0);
+    } finally {
+      statSpy.mockRestore();
+    }
+  });
+
+  it("returns UnexpectedError when metadata assembly fails unexpectedly", async () => {
+    const { flowPath, runPath } = createFixture("nangate45", "gcd", "run-123", ["cts_clk.webp"]);
+    (getSettings as ReturnType<typeof vi.fn>).mockReturnValue({
+      platforms: ["nangate45"],
+      designs: (p: string) => (p === "nangate45" ? ["gcd"] : []),
+      flowPath,
+      WHITELIST_ENABLED: false,
+    });
+    const imagePath = path.join(runPath, "cts_clk.webp");
+    const originalStatSync = fs.statSync.bind(fs);
+    const statSpy = vi.spyOn(fs, "statSync").mockImplementation((p) => {
+      const real = originalStatSync(p) as fs.Stats;
+      if (p === imagePath) {
+        // Mutate in place (not a spread copy) so prototype methods like
+        // isFile() survive; a corrupt mtime makes stat.mtime.toISOString()
+        // throw deep inside metadata assembly, after the size/existence checks pass.
+        Object.defineProperty(real, "mtime", { value: undefined, configurable: true });
+      }
+      return real;
+    });
+    try {
+      const raw = await new ReadReportImageTool(stubManager).execute("nangate45", "gcd", "run-123", "cts_clk.webp");
+      const result = JSON.parse(raw);
+      expect(result.error).toBe("UnexpectedError");
+    } finally {
+      statSpy.mockRestore();
+    }
   });
 });

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -2367,9 +2367,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -3011,9 +3011,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -3255,9 +3255,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.30",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.30.tgz",
-      "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -3905,9 +3905,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -24,6 +24,7 @@
     "build": "tsc --project tsconfig.json",
     "typecheck": "tsc --noEmit && tsc -p tsconfig.test.json",
     "lint": "eslint .",
+    "audit": "npm audit --audit-level=high",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:integration": "vitest run --config vitest.config.integration.ts",

--- a/typescript/vitest.config.ts
+++ b/typescript/vitest.config.ts
@@ -9,7 +9,27 @@ export default defineConfig({
     exclude: ["__tests__/integration/**", "__tests__/performance/**"],
     coverage: {
       provider: "v8",
-      thresholds: { lines: 80 },
+      thresholds: {
+        // Repo-wide floor.
+        lines: 80,
+
+        // Per-file floors for the critical modules (session lifecycle,
+        // the Tcl whitelist, report-image path security, tool dispatch).
+        // Set a little below the measured level at the time they were
+        // added so the floor has headroom, not exactly equal to it.
+        "src/config/command_whitelist.ts": { statements: 90, branches: 88 },
+        "src/tools/base.ts": { statements: 100, branches: 100 },
+        "src/tools/interactive.ts": { statements: 90, branches: 75 },
+        "src/core/manager.ts": { statements: 95, branches: 90 },
+        "src/tools/report_images.ts": { statements: 95, branches: 80 },
+
+        // server.ts is mostly transport/tool-registration wiring exercised
+        // by the Docker-based real-OpenROAD integration suite (see
+        // .github/workflows/docker-test.yml), not by this unit-only run —
+        // this floor only guards against regressing below where it sits
+        // today, not a 90% unit-coverage target.
+        "src/server.ts": { statements: 25, branches: 5 },
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary

Strengthens the TypeScript-first CI and release pipeline to restore the validation depth previously provided by the Python/`uv` workflows.

- Enforce dependency security, type checking, linting, and coverage through shared CI setup.
- Restore meaningful cross-platform validation on Ubuntu 22, Ubuntu 24, and macOS 14.
- Make real-OpenROAD Docker testing an explicit PR and release gate.
- Add targeted coverage for session lifecycle and report-image security paths.
- Update legacy setup/documentation paths for the Node-based distribution.

## Changes

### CI and release hardening

- Add a shared `ts-checks` composite action for Node setup, `npm ci`, `npm audit`, type checking, and linting.
- Add `npm audit --audit-level=high` as a blocking CI and release check.
- Extract the real-OpenROAD Docker test into a reusable workflow.
- Require the Docker test stage before npm publishing, GHCR publishing, GitHub release creation, and MCP Registry publishing.
- Verify `openroad -version` while building the Docker test stage so the real-OpenROAD suite cannot silently skip.
- Retain nightly TypeScript performance benchmarks.

### Cross-platform validation

- Restore the weekly Sunday cross-platform run.
- Update Ubuntu and macOS setup scripts to provision the Node/TypeScript workflow instead of deprecated Python/`uv`.
- Run unit and generic PTY integration tests on Ubuntu 22, Ubuntu 24, and macOS 14 after setup.
- Document that only the OpenROAD REPL integration suite requires an OpenROAD installation; generic PTY integration tests run without it.

### Test coverage

- Add session-manager lifecycle and error-path tests.
- Add report-image traversal and size-limit tests.
- Add per-module coverage floors for critical security and lifecycle code:
  - command whitelist
  - base and interactive tools
  - session manager
  - report-image handling
  - server registration/transport wiring
